### PR TITLE
Extract SubtopicsFocusModal and GoalsModal into reusable components

### DIFF
--- a/src/components/GenerateQuestionsModal.js
+++ b/src/components/GenerateQuestionsModal.js
@@ -18,7 +18,7 @@ const GenerateQuestionsModal = ({ isOpen, onClose, onGenerated }) => {
   const [grade, setGrade] = useState(GRADES.G3);
   const [topic, setTopic] = useState('');
   const [questionTypes, setQuestionTypes] = useState([QUESTION_TYPES.MULTIPLE_CHOICE]);
-  const [count, setCount] = useState(10);
+  const [count, setCount] = useState('10');
   const [additionalInstructions, setAdditionalInstructions] = useState('');
   const [generating, setGenerating] = useState(false);
   const [progress, setProgress] = useState({ completed: 0, total: 0 });
@@ -57,7 +57,8 @@ const GenerateQuestionsModal = ({ isOpen, onClose, onGenerated }) => {
     cancelledRef.current = false;
 
     const allQuestions = [];
-    const totalCount = Math.min(Math.max(count, 1), MAX_QUESTIONS);
+    const parsedCount = parseInt(count, 10);
+    const totalCount = Math.min(Math.max(Number.isFinite(parsedCount) ? parsedCount : 1, 1), MAX_QUESTIONS);
     const totalBatches = Math.ceil(totalCount / BATCH_SIZE);
 
     try {
@@ -204,7 +205,17 @@ const GenerateQuestionsModal = ({ isOpen, onClose, onGenerated }) => {
             <input
               type="number"
               value={count}
-              onChange={(e) => setCount(Math.min(Math.max(parseInt(e.target.value) || 1, 1), MAX_QUESTIONS))}
+              onChange={(e) => setCount(e.target.value)}
+              onBlur={() => {
+                const parsed = parseInt(count, 10);
+                if (!Number.isFinite(parsed) || parsed < 1) {
+                  setCount('1');
+                } else if (parsed > MAX_QUESTIONS) {
+                  setCount(String(MAX_QUESTIONS));
+                } else {
+                  setCount(String(parsed));
+                }
+              }}
               disabled={generating}
               min={1}
               max={MAX_QUESTIONS}

--- a/src/components/ImageGenerationModal.js
+++ b/src/components/ImageGenerationModal.js
@@ -11,7 +11,7 @@ const ImageGenerationModal = ({ isOpen, onClose, onSuccess }) => {
   const [step, setStep] = useState(1);
   const [theme, setTheme] = useState('');
   const [themeDescription, setThemeDescription] = useState('');
-  const [count, setCount] = useState(3);
+  const [count, setCount] = useState('3');
   const [descriptions, setDescriptions] = useState([]);
   const [generatedImages, setGeneratedImages] = useState([]);
   const [selectedIndices, setSelectedIndices] = useState([]);
@@ -51,7 +51,7 @@ const ImageGenerationModal = ({ isOpen, onClose, onSuccess }) => {
       setStep(1);
       setTheme('');
       setThemeDescription('');
-      setCount(3);
+      setCount('3');
       setDescriptions([]);
       setGeneratedImages([]);
       setSelectedIndices([]);
@@ -168,7 +168,8 @@ const ImageGenerationModal = ({ isOpen, onClose, onSuccess }) => {
   };
 
   const handleGenerateDescriptions = async () => {
-    if (!theme.trim() || !themeDescription.trim() || count < 1 || count > 10) {
+    const parsedCount = parseInt(count, 10);
+    if (!theme.trim() || !themeDescription.trim() || !Number.isFinite(parsedCount) || parsedCount < 1 || parsedCount > 10) {
       setError('Please enter a valid theme name, theme description, and count (1-10)');
       return;
     }
@@ -208,7 +209,7 @@ const ImageGenerationModal = ({ isOpen, onClose, onSuccess }) => {
           action: 'generate-descriptions',
           theme: theme.trim(),
           themeDescription: themeDescription.trim(),
-          count: parseInt(count),
+          count: parsedCount,
         }),
       });
 
@@ -504,7 +505,7 @@ const ImageGenerationModal = ({ isOpen, onClose, onSuccess }) => {
     setStep(1);
     setTheme('');
     setThemeDescription('');
-    setCount(3);
+    setCount('3');
     setDescriptions([]);
     setGeneratedImages([]);
     setSelectedIndices([]);
@@ -557,7 +558,14 @@ const ImageGenerationModal = ({ isOpen, onClose, onSuccess }) => {
 
   const canGoNext = () => {
     if (step === 1) {
-      return theme.trim() && themeDescription.trim() && count >= 1 && count <= 10;
+      const parsedCount = parseInt(count, 10);
+      return Boolean(
+        theme.trim() &&
+        themeDescription.trim() &&
+        Number.isFinite(parsedCount) &&
+        parsedCount >= 1 &&
+        parsedCount <= 10
+      );
     } else if (step === 2) {
       return descriptions.length > 0;
     } else if (step === 3) {
@@ -686,7 +694,17 @@ const ImageGenerationModal = ({ isOpen, onClose, onSuccess }) => {
                   min="1"
                   max="10"
                   value={count}
-                  onChange={(e) => setCount(Math.max(1, Math.min(10, parseInt(e.target.value) || 1)))}
+                  onChange={(e) => setCount(e.target.value)}
+                  onBlur={() => {
+                    const parsed = parseInt(count, 10);
+                    if (!Number.isFinite(parsed) || parsed < 1) {
+                      setCount('1');
+                    } else if (parsed > 10) {
+                      setCount('10');
+                    } else {
+                      setCount(String(parsed));
+                    }
+                  }}
                   className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                 />
                 <p className="text-xs text-gray-500 mt-1">

--- a/src/components/__tests__/GenerateQuestionsModal.count.test.js
+++ b/src/components/__tests__/GenerateQuestionsModal.count.test.js
@@ -1,0 +1,138 @@
+// Tests for the "Number of Questions" input reset behavior in GenerateQuestionsModal.
+// Bug: previously the onChange handler clamped every keystroke (e.g. parseInt('') || 1),
+// so the user could never clear the field — typing after backspacing yielded weird
+// values like "10" being unable to be reset to a smaller number.
+const React = require('react');
+const { render, screen, fireEvent, waitFor } = require('@testing-library/react');
+const { VALID_TOPICS_BY_GRADE, GRADES, QUESTION_TYPES } = require('../../constants/topics');
+
+jest.mock('firebase/auth', () => ({
+  getAuth: jest.fn(() => ({
+    currentUser: {
+      getIdToken: jest.fn().mockResolvedValue('mock-token'),
+    },
+  })),
+}));
+
+jest.mock('../ui/ModalWrapper', () => {
+  const React = require('react');
+  return function MockModalWrapper({ isOpen, children, title }) {
+    if (!isOpen) return null;
+    return React.createElement('div', null, [
+      React.createElement('h1', { key: 'title' }, title),
+      React.createElement('div', { key: 'content' }, children),
+    ]);
+  };
+});
+
+const { getAuth } = require('firebase/auth');
+const GenerateQuestionsModal = require('../GenerateQuestionsModal').default;
+
+const findCountInput = () => {
+  const numberInputs = document.querySelectorAll('input[type="number"]');
+  // There is exactly one number input on this form: "Number of Questions"
+  return numberInputs[0];
+};
+
+describe('GenerateQuestionsModal - count input reset behavior', () => {
+  beforeEach(() => {
+    getAuth.mockReturnValue({
+      currentUser: { getIdToken: jest.fn().mockResolvedValue('mock-token') },
+    });
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ questions: [] }),
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('user can clear the count field and type a new value', () => {
+    render(
+      React.createElement(GenerateQuestionsModal, {
+        isOpen: true,
+        onClose: jest.fn(),
+        onGenerated: jest.fn(),
+      })
+    );
+
+    const input = findCountInput();
+    expect(input).toBeTruthy();
+    expect(input.value).toBe('10');
+
+    // Simulate user clearing the field — the value should be allowed to be empty.
+    fireEvent.change(input, { target: { value: '' } });
+    expect(input.value).toBe('');
+
+    // User types "5" — should be 5, NOT "15" or "10".
+    fireEvent.change(input, { target: { value: '5' } });
+    expect(input.value).toBe('5');
+  });
+
+  test('blur on empty input snaps to minimum (1) instead of jumping back to 10', () => {
+    render(
+      React.createElement(GenerateQuestionsModal, {
+        isOpen: true,
+        onClose: jest.fn(),
+        onGenerated: jest.fn(),
+      })
+    );
+
+    const input = findCountInput();
+
+    fireEvent.change(input, { target: { value: '' } });
+    fireEvent.blur(input);
+
+    // Empty must not silently become the default 10.
+    expect(input.value).toBe('1');
+  });
+
+  test('blur clamps values above the maximum down to MAX_QUESTIONS', () => {
+    render(
+      React.createElement(GenerateQuestionsModal, {
+        isOpen: true,
+        onClose: jest.fn(),
+        onGenerated: jest.fn(),
+      })
+    );
+
+    const input = findCountInput();
+
+    fireEvent.change(input, { target: { value: '999' } });
+    fireEvent.blur(input);
+
+    // 999 must clamp to MAX_QUESTIONS (15) on blur.
+    expect(input.value).toBe('15');
+  });
+
+  test('generation payload uses the user-edited count, not the default', async () => {
+    const onGenerated = jest.fn();
+    render(
+      React.createElement(GenerateQuestionsModal, {
+        isOpen: true,
+        onClose: jest.fn(),
+        onGenerated,
+      })
+    );
+
+    const selects = screen.getAllByRole('combobox');
+    const topicSelect = selects[1];
+    fireEvent.change(topicSelect, { target: { value: VALID_TOPICS_BY_GRADE[GRADES.G3][0] } });
+
+    const input = findCountInput();
+    fireEvent.change(input, { target: { value: '' } });
+    fireEvent.change(input, { target: { value: '4' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Generate' }));
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    const [, options] = global.fetch.mock.calls[0];
+    const payload = JSON.parse(options.body);
+
+    expect(payload.count).toBe(4);
+    expect(payload.questionTypes).toContain(QUESTION_TYPES.MULTIPLE_CHOICE);
+  });
+});

--- a/src/components/__tests__/ImageGenerationModal.count.test.js
+++ b/src/components/__tests__/ImageGenerationModal.count.test.js
@@ -1,0 +1,104 @@
+// Tests for the "Number of Images" input reset behavior in ImageGenerationModal.
+// Same class of bug as GenerateQuestionsModal: the user could not clear the field
+// because the onChange handler clamped on every keystroke.
+const React = require('react');
+const { render, fireEvent, screen } = require('@testing-library/react');
+
+jest.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: { getIdToken: jest.fn().mockResolvedValue('mock-token') },
+  }),
+}));
+
+const ImageGenerationModal = require('../ImageGenerationModal').default;
+
+const findCountInput = () => {
+  const inputs = document.querySelectorAll('input[type="number"]');
+  return inputs[0];
+};
+
+describe('ImageGenerationModal - count input reset behavior', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('user can clear the count field and type a different value', () => {
+    render(
+      React.createElement(ImageGenerationModal, {
+        isOpen: true,
+        onClose: jest.fn(),
+        onSuccess: jest.fn(),
+      })
+    );
+
+    const input = findCountInput();
+    expect(input).toBeTruthy();
+    expect(input.value).toBe('3');
+
+    fireEvent.change(input, { target: { value: '' } });
+    expect(input.value).toBe('');
+
+    fireEvent.change(input, { target: { value: '7' } });
+    expect(input.value).toBe('7');
+  });
+
+  test('blurring an empty input snaps to 1, not back to the default 3', () => {
+    render(
+      React.createElement(ImageGenerationModal, {
+        isOpen: true,
+        onClose: jest.fn(),
+        onSuccess: jest.fn(),
+      })
+    );
+
+    const input = findCountInput();
+    fireEvent.change(input, { target: { value: '' } });
+    fireEvent.blur(input);
+    expect(input.value).toBe('1');
+  });
+
+  test('blur clamps an above-max value down to 10', () => {
+    render(
+      React.createElement(ImageGenerationModal, {
+        isOpen: true,
+        onClose: jest.fn(),
+        onSuccess: jest.fn(),
+      })
+    );
+
+    const input = findCountInput();
+    fireEvent.change(input, { target: { value: '500' } });
+    fireEvent.blur(input);
+    expect(input.value).toBe('10');
+  });
+
+  test('Generate Descriptions button is disabled when count is empty (and re-enables after typing valid value)', () => {
+    render(
+      React.createElement(ImageGenerationModal, {
+        isOpen: true,
+        onClose: jest.fn(),
+        onSuccess: jest.fn(),
+      })
+    );
+
+    // Fill required theme fields so only count gates the button.
+    const themeInput = screen.getByPlaceholderText(/safari, space, ocean, fantasy/i);
+    fireEvent.change(themeInput, { target: { value: 'Safari' } });
+    const themeDescription = screen.getByPlaceholderText(/safari animals/i);
+    fireEvent.change(themeDescription, { target: { value: 'Test description' } });
+
+    const next = screen.getByRole('button', { name: /generate descriptions/i });
+    expect(next).not.toBeDisabled();
+
+    const input = findCountInput();
+    fireEvent.change(input, { target: { value: '' } });
+    expect(next).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: '4' } });
+    expect(next).not.toBeDisabled();
+  });
+});

--- a/src/components/portal/GoalsModal.js
+++ b/src/components/portal/GoalsModal.js
@@ -1,0 +1,250 @@
+import React, { useEffect, useState } from 'react';
+import { Target, Loader2, AlertCircle } from 'lucide-react';
+import ModalWrapper from '../ui/ModalWrapper';
+import { getTopicsForGrade } from '../../utils/common_utils';
+
+const DEFAULT_TARGET = 4;
+
+const clampNonNegative = (raw) => {
+  const parsed = parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) return 0;
+  return parsed;
+};
+
+const buildInitialTargets = (grade, existingTargets) => {
+  const topics = getTopicsForGrade(grade);
+  const next = {};
+  topics.forEach((topic) => {
+    const existing = existingTargets ? existingTargets[topic] : undefined;
+    next[topic] = existing === undefined || existing === null ? String(DEFAULT_TARGET) : String(existing);
+  });
+  return next;
+};
+
+const GoalsModal = ({
+  isOpen,
+  onClose,
+  initialGrade = 'G3',
+  initialTargets,
+  studentCount = 1,
+  onSave,
+}) => {
+  const [grade, setGrade] = useState(initialGrade);
+  const [targets, setTargets] = useState(() => buildInitialTargets(initialGrade, initialTargets));
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      setGrade(initialGrade);
+      setTargets(buildInitialTargets(initialGrade, initialTargets));
+      setError(null);
+    }
+  }, [isOpen, initialGrade, initialTargets]);
+
+  const handleGradeChange = (nextGrade) => {
+    const topics = getTopicsForGrade(nextGrade);
+    const next = { ...targets };
+    topics.forEach((topic) => {
+      if (next[topic] === undefined) next[topic] = String(DEFAULT_TARGET);
+    });
+    setGrade(nextGrade);
+    setTargets(next);
+  };
+
+  const handleTargetChange = (topic, raw) => {
+    setTargets((prev) => ({ ...prev, [topic]: raw }));
+  };
+
+  const handleTargetBlur = (topic) => {
+    setTargets((prev) => {
+      const raw = prev[topic];
+      const parsed = parseInt(raw, 10);
+      const next = !Number.isFinite(parsed) || parsed < 0 ? '0' : String(parsed);
+      if (next === raw) return prev;
+      return { ...prev, [topic]: next };
+    });
+  };
+
+  const handleApplyAll = (raw) => {
+    const value = clampNonNegative(raw);
+    const topics = getTopicsForGrade(grade);
+    setTargets((prev) => {
+      const next = { ...prev };
+      topics.forEach((topic) => {
+        next[topic] = String(value);
+      });
+      return next;
+    });
+  };
+
+  const handleSave = async () => {
+    if (!onSave) {
+      onClose();
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      const topics = getTopicsForGrade(grade);
+      const numericTargets = {};
+      topics.forEach((topic) => {
+        numericTargets[topic] = clampNonNegative(targets[topic]);
+      });
+      await onSave({ grade, targets: numericTargets });
+      onClose();
+    } catch (err) {
+      console.error('Error saving goals:', err);
+      setError(err.message || 'Failed to save goals.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  const topics = getTopicsForGrade(grade);
+  const totalDaily = topics.reduce((sum, t) => sum + clampNonNegative(targets[t]), 0);
+
+  return (
+    <ModalWrapper isOpen={isOpen} onClose={onClose} title="" size="lg" hideCloseButton>
+      <div className="bg-gradient-to-r from-blue-600 to-cyan-600 text-white px-6 py-5 flex items-center justify-between">
+        <div className="flex items-center space-x-3">
+          <div className="bg-white/20 rounded-full p-2">
+            <Target className="h-5 w-5" />
+          </div>
+          <div>
+            <h2 className="text-lg font-semibold">Set daily goals</h2>
+            <p className="text-sm text-blue-100">
+              Choose how many questions per topic{' '}
+              <strong>
+                {studentCount} student{studentCount === 1 ? '' : 's'}
+              </strong>{' '}
+              should answer each day.
+            </p>
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-white/80 hover:text-white text-2xl leading-none"
+          aria-label="Close"
+        >
+          ×
+        </button>
+      </div>
+
+      <div className="px-6 py-5 space-y-5">
+        {error && (
+          <div className="flex items-start gap-3 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800">
+            <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+            <span>{error}</span>
+          </div>
+        )}
+
+        <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-3">
+          <div>
+            <label className="block text-xs font-semibold text-gray-600 uppercase tracking-wide mb-1">
+              Grade
+            </label>
+            <select
+              value={grade}
+              onChange={(e) => handleGradeChange(e.target.value)}
+              className="border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="G3">Grade 3</option>
+              <option value="G4">Grade 4</option>
+            </select>
+          </div>
+          <div className="flex items-end gap-2">
+            <div>
+              <label className="block text-xs font-semibold text-gray-600 uppercase tracking-wide mb-1">
+                Apply to all topics
+              </label>
+              <div className="flex items-stretch border border-gray-300 rounded-md overflow-hidden">
+                <input
+                  type="number"
+                  min="0"
+                  defaultValue={DEFAULT_TARGET}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      handleApplyAll(e.currentTarget.value);
+                    }
+                  }}
+                  className="w-20 px-3 py-2 text-sm focus:outline-none"
+                  aria-label="Apply same goal to all topics"
+                />
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    const input = e.currentTarget.previousSibling;
+                    handleApplyAll(input.value);
+                  }}
+                  className="px-3 bg-gray-100 text-sm font-medium text-gray-700 hover:bg-gray-200 border-l border-gray-300"
+                >
+                  Apply
+                </button>
+              </div>
+            </div>
+            <div className="hidden sm:block ml-2 text-xs text-gray-500 pb-2">
+              Daily total:{' '}
+              <span className="font-semibold text-gray-800">
+                {totalDaily} question{totalDaily === 1 ? '' : 's'}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          {topics.map((topic) => (
+            <div
+              key={topic}
+              className="flex items-center justify-between border border-gray-200 rounded-lg px-4 py-3 hover:border-blue-300 transition-colors bg-white"
+            >
+              <span className="text-sm font-medium text-gray-800 mr-3 truncate" title={topic}>
+                {topic}
+              </span>
+              <div className="flex items-center gap-2">
+                <input
+                  type="number"
+                  min="0"
+                  value={targets[topic] ?? ''}
+                  onChange={(e) => handleTargetChange(topic, e.target.value)}
+                  onBlur={() => handleTargetBlur(topic)}
+                  className="w-20 border border-gray-300 rounded-md px-2 py-1 text-sm text-right focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+                <span className="text-xs text-gray-500">/ day</span>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="sm:hidden text-xs text-gray-500">
+          Daily total: <span className="font-semibold text-gray-800">{totalDaily}</span>
+        </div>
+      </div>
+
+      <div className="px-6 py-4 border-t border-gray-200 bg-gray-50 flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={onClose}
+          disabled={saving}
+          className="px-4 py-2 rounded-md border border-gray-300 bg-white text-sm font-medium text-gray-700 hover:bg-gray-100 disabled:opacity-50"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={saving}
+          className="inline-flex items-center px-4 py-2 rounded-md bg-blue-600 text-white text-sm font-medium hover:bg-blue-700 disabled:opacity-50"
+        >
+          {saving && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
+          {saving ? 'Saving…' : 'Save goals'}
+        </button>
+      </div>
+    </ModalWrapper>
+  );
+};
+
+export default GoalsModal;

--- a/src/components/portal/GoalsModal.js
+++ b/src/components/portal/GoalsModal.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Target, Loader2, AlertCircle } from 'lucide-react';
 import ModalWrapper from '../ui/ModalWrapper';
 import { getTopicsForGrade } from '../../utils/common_utils';
@@ -33,6 +33,7 @@ const GoalsModal = ({
   const [targets, setTargets] = useState(() => buildInitialTargets(initialGrade, initialTargets));
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState(null);
+  const applyAllInputRef = useRef(null);
 
   useEffect(() => {
     if (isOpen) {
@@ -163,6 +164,7 @@ const GoalsModal = ({
               </label>
               <div className="flex items-stretch border border-gray-300 rounded-md overflow-hidden">
                 <input
+                  ref={applyAllInputRef}
                   type="number"
                   min="0"
                   defaultValue={DEFAULT_TARGET}
@@ -176,9 +178,10 @@ const GoalsModal = ({
                 />
                 <button
                   type="button"
-                  onClick={(e) => {
-                    const input = e.currentTarget.previousSibling;
-                    handleApplyAll(input.value);
+                  onClick={() => {
+                    if (applyAllInputRef.current) {
+                      handleApplyAll(applyAllInputRef.current.value);
+                    }
                   }}
                   className="px-3 bg-gray-100 text-sm font-medium text-gray-700 hover:bg-gray-200 border-l border-gray-300"
                 >

--- a/src/components/portal/SubtopicsFocusModal.js
+++ b/src/components/portal/SubtopicsFocusModal.js
@@ -1,0 +1,292 @@
+import React, { useEffect, useState, useMemo } from 'react';
+import { Target, Sparkles, AlertCircle, Loader2 } from 'lucide-react';
+import { getFirestore, doc, getDoc, updateDoc } from 'firebase/firestore';
+import ModalWrapper from '../ui/ModalWrapper';
+import { getTopicsForGrade, getAppId } from '../../utils/common_utils';
+import { getSubtopicsForTopic } from '../../utils/subtopicUtils';
+import { getStudentDisplayName } from '../../utils/studentName';
+
+const SubtopicsFocusModal = ({
+  isOpen,
+  onClose,
+  student,
+  classId,
+  initialAllowedSubtopicsByTopic,
+  onSaved,
+}) => {
+  const appId = getAppId();
+  const db = getFirestore();
+
+  const initialGrade = student?.grade || student?.selectedGrade || 'G3';
+  const initialTopics = useMemo(() => getTopicsForGrade(initialGrade), [initialGrade]);
+
+  const [grade, setGrade] = useState(initialGrade);
+  const [topic, setTopic] = useState(initialTopics[0] || '');
+  const [allowedByTopic, setAllowedByTopic] = useState(initialAllowedSubtopicsByTopic || {});
+  const [selectedSubtopics, setSelectedSubtopics] = useState(
+    (initialAllowedSubtopicsByTopic && initialAllowedSubtopicsByTopic[initialTopics[0]]) || []
+  );
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const startGrade = student?.grade || student?.selectedGrade || 'G3';
+    const startTopics = getTopicsForGrade(startGrade);
+    const startTopic = startTopics[0] || '';
+    setGrade(startGrade);
+    setTopic(startTopic);
+    setAllowedByTopic(initialAllowedSubtopicsByTopic || {});
+    setSelectedSubtopics(
+      (initialAllowedSubtopicsByTopic && initialAllowedSubtopicsByTopic[startTopic]) || []
+    );
+    setError(null);
+  }, [isOpen, student, initialAllowedSubtopicsByTopic]);
+
+  const subtopics = useMemo(() => {
+    if (!topic) return [];
+    const result = getSubtopicsForTopic(topic, grade);
+    return Array.isArray(result) ? result : [];
+  }, [topic, grade]);
+
+  const handleGradeChange = (nextGrade) => {
+    const nextTopics = getTopicsForGrade(nextGrade);
+    const nextTopic = nextTopics[0] || '';
+    setGrade(nextGrade);
+    setTopic(nextTopic);
+    setSelectedSubtopics(allowedByTopic[nextTopic] || []);
+  };
+
+  const handleTopicChange = (nextTopic) => {
+    setTopic(nextTopic);
+    setSelectedSubtopics(allowedByTopic[nextTopic] || []);
+  };
+
+  const handleToggle = (sub) => {
+    setSelectedSubtopics((prev) =>
+      prev.includes(sub) ? prev.filter((s) => s !== sub) : [...prev, sub]
+    );
+  };
+
+  const handleSelectAll = () => {
+    setSelectedSubtopics(subtopics);
+  };
+
+  const handleClearAll = () => {
+    setSelectedSubtopics([]);
+  };
+
+  const handleSave = async () => {
+    if (!classId) {
+      setError('This student is not enrolled in a class. Assign the student to a class first.');
+      return;
+    }
+    if (!student?.id || !topic) return;
+
+    setSaving(true);
+    setError(null);
+
+    try {
+      const enrollmentId = `${classId}__${student.id}`;
+      const enrollmentRef = doc(db, 'artifacts', appId, 'classStudents', enrollmentId);
+      const snap = await getDoc(enrollmentRef);
+      const current = snap.exists() ? (snap.data().allowedSubtopicsByTopic || {}) : {};
+
+      const updated = { ...current, [topic]: selectedSubtopics };
+      if (selectedSubtopics.length === 0) {
+        delete updated[topic];
+      }
+
+      await updateDoc(enrollmentRef, {
+        allowedSubtopicsByTopic: updated,
+      });
+
+      setAllowedByTopic(updated);
+      if (onSaved) onSaved(updated);
+      onClose();
+    } catch (err) {
+      console.error('Error saving subtopic focus:', err);
+      setError(err.message || 'Failed to save focus subtopics.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  const studentName = student ? getStudentDisplayName(student) : 'Student';
+  const focusedTopicCount = Object.keys(allowedByTopic).filter(
+    (k) => Array.isArray(allowedByTopic[k]) && allowedByTopic[k].length > 0
+  ).length;
+
+  return (
+    <ModalWrapper isOpen={isOpen} onClose={onClose} title="" size="md" hideCloseButton>
+      <div className="bg-gradient-to-r from-purple-600 to-indigo-600 text-white px-6 py-5 flex items-center justify-between">
+        <div className="flex items-center space-x-3">
+          <div className="bg-white/20 rounded-full p-2">
+            <Target className="h-5 w-5" />
+          </div>
+          <div>
+            <h2 className="text-lg font-semibold">Focus subtopics</h2>
+            <p className="text-sm text-purple-100">
+              Tailor what {studentName} practices.
+            </p>
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-white/80 hover:text-white text-2xl leading-none"
+          aria-label="Close"
+        >
+          ×
+        </button>
+      </div>
+
+      <div className="px-6 py-5 space-y-5">
+        {!classId && (
+          <div className="flex items-start gap-3 rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+            <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+            <span>
+              {studentName} is not assigned to a class yet, so focus settings can't be saved.
+              Assign them to a class first.
+            </span>
+          </div>
+        )}
+
+        {error && (
+          <div className="flex items-start gap-3 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800">
+            <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+            <span>{error}</span>
+          </div>
+        )}
+
+        <div className="rounded-lg bg-purple-50 border border-purple-100 px-4 py-3 text-xs text-purple-900 flex items-start gap-2">
+          <Sparkles className="h-4 w-4 mt-0.5 flex-shrink-0" />
+          <span>
+            Pick the subtopics this student should practice. Leave a topic empty to include every subtopic.
+            {focusedTopicCount > 0 && (
+              <> Currently focused on <strong>{focusedTopicCount}</strong> topic
+                {focusedTopicCount === 1 ? '' : 's'}.</>
+            )}
+          </span>
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <div>
+            <label className="block text-xs font-semibold text-gray-600 uppercase tracking-wide mb-1">Grade</label>
+            <select
+              value={grade}
+              onChange={(e) => handleGradeChange(e.target.value)}
+              className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-purple-500"
+            >
+              <option value="G3">Grade 3</option>
+              <option value="G4">Grade 4</option>
+            </select>
+          </div>
+          <div>
+            <label className="block text-xs font-semibold text-gray-600 uppercase tracking-wide mb-1">Topic</label>
+            <select
+              value={topic}
+              onChange={(e) => handleTopicChange(e.target.value)}
+              className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-purple-500"
+            >
+              {getTopicsForGrade(grade).map((t) => (
+                <option key={t} value={t}>{t}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div>
+          <div className="flex items-center justify-between mb-2">
+            <label className="text-sm font-medium text-gray-700">
+              Subtopics
+              {selectedSubtopics.length > 0 && (
+                <span className="ml-2 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-700">
+                  {selectedSubtopics.length} selected
+                </span>
+              )}
+            </label>
+            {subtopics.length > 0 && (
+              <div className="flex items-center space-x-2 text-xs">
+                <button
+                  type="button"
+                  onClick={handleSelectAll}
+                  className="text-purple-700 hover:text-purple-900 font-medium"
+                >
+                  Select all
+                </button>
+                <span className="text-gray-300">|</span>
+                <button
+                  type="button"
+                  onClick={handleClearAll}
+                  className="text-gray-600 hover:text-gray-800 font-medium"
+                >
+                  Clear
+                </button>
+              </div>
+            )}
+          </div>
+
+          <div className="rounded-lg border border-gray-200 bg-gray-50 max-h-64 overflow-y-auto">
+            {subtopics.length === 0 ? (
+              <p className="text-sm text-gray-500 italic px-4 py-6 text-center">
+                This topic does not define subtopics.
+              </p>
+            ) : (
+              <ul className="divide-y divide-gray-200">
+                {subtopics.map((sub) => {
+                  const checked = selectedSubtopics.includes(sub);
+                  return (
+                    <li key={sub}>
+                      <label className="flex items-center space-x-3 px-4 py-2 hover:bg-white cursor-pointer">
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          onChange={() => handleToggle(sub)}
+                          className="h-4 w-4 text-purple-600 focus:ring-purple-500 border-gray-300 rounded"
+                        />
+                        <span className="text-sm text-gray-800">{sub}</span>
+                      </label>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+
+          <p className="mt-2 text-xs text-gray-500">
+            {selectedSubtopics.length === 0
+              ? 'Empty selection means all subtopics are allowed for this topic.'
+              : `Only the ${selectedSubtopics.length} selected subtopic${
+                  selectedSubtopics.length === 1 ? '' : 's'
+                } will be served to this student for ${topic}.`}
+          </p>
+        </div>
+      </div>
+
+      <div className="px-6 py-4 border-t border-gray-200 bg-gray-50 flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={onClose}
+          disabled={saving}
+          className="px-4 py-2 rounded-md border border-gray-300 bg-white text-sm font-medium text-gray-700 hover:bg-gray-100 disabled:opacity-50"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={saving || !classId}
+          className="inline-flex items-center px-4 py-2 rounded-md bg-purple-600 text-white text-sm font-medium hover:bg-purple-700 disabled:opacity-50"
+        >
+          {saving && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
+          {saving ? 'Saving…' : 'Save focus'}
+        </button>
+      </div>
+    </ModalWrapper>
+  );
+};
+
+export default SubtopicsFocusModal;

--- a/src/components/portal/SubtopicsFocusModal.js
+++ b/src/components/portal/SubtopicsFocusModal.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useMemo } from 'react';
 import { Target, Sparkles, AlertCircle, Loader2 } from 'lucide-react';
-import { getFirestore, doc, getDoc, updateDoc } from 'firebase/firestore';
+import { getFirestore, doc, getDoc, setDoc } from 'firebase/firestore';
 import ModalWrapper from '../ui/ModalWrapper';
 import { getTopicsForGrade, getAppId } from '../../utils/common_utils';
 import { getSubtopicsForTopic } from '../../utils/subtopicUtils';
@@ -97,9 +97,9 @@ const SubtopicsFocusModal = ({
         delete updated[topic];
       }
 
-      await updateDoc(enrollmentRef, {
-        allowedSubtopicsByTopic: updated,
-      });
+      // setDoc with merge so we don't fail when the enrollment doc is missing
+      // (legacy data) and we don't clobber other fields on existing docs.
+      await setDoc(enrollmentRef, { allowedSubtopicsByTopic: updated }, { merge: true });
 
       setAllowedByTopic(updated);
       if (onSaved) onSaved(updated);

--- a/src/components/portal/__tests__/GoalsModal.test.js
+++ b/src/components/portal/__tests__/GoalsModal.test.js
@@ -1,0 +1,115 @@
+// Tests for the new friendly GoalsModal component used in the teacher portal.
+// Covers:
+//   - Rendering with title, grade, and per-topic inputs
+//   - "Apply to all topics" bulk-apply
+//   - Number input behavior (allow clearing, clamp on blur)
+//   - Save callback receives normalized integer targets
+const React = require('react');
+const { render, screen, fireEvent, waitFor, within } = require('@testing-library/react');
+
+jest.mock('../../ui/ModalWrapper', () => {
+  const React = require('react');
+  return function MockModalWrapper({ isOpen, children }) {
+    if (!isOpen) return null;
+    return React.createElement('div', { 'data-testid': 'modal' }, children);
+  };
+});
+
+const GoalsModal = require('../GoalsModal').default;
+
+const G3_TOPICS = ['Multiplication', 'Division', 'Fractions', 'Measurement & Data'];
+
+const renderModal = (overrides = {}) => {
+  const props = {
+    isOpen: true,
+    onClose: jest.fn(),
+    initialGrade: 'G3',
+    initialTargets: {},
+    studentCount: 1,
+    onSave: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+  return { props, ...render(React.createElement(GoalsModal, props)) };
+};
+
+describe('GoalsModal', () => {
+  test('renders one numeric input per Grade 3 topic with default target of 4', () => {
+    renderModal();
+
+    G3_TOPICS.forEach((topic) => {
+      expect(screen.getByText(topic)).toBeInTheDocument();
+    });
+
+    // The per-topic inputs default to "4".
+    // Filter out the "Apply to all topics" input by aria-label.
+    const perTopicInputs = screen
+      .getAllByRole('spinbutton')
+      .filter((el) => el.value === '4' && el.getAttribute('aria-label') !== 'Apply same goal to all topics');
+    expect(perTopicInputs.length).toBe(G3_TOPICS.length);
+  });
+
+  test('clearing a per-topic input is allowed during typing and snaps to 0 on blur', () => {
+    renderModal({ initialTargets: { Multiplication: 7 } });
+
+    const inputs = screen.getAllByRole('spinbutton');
+    // Find the input whose displayed value is 7 — the one we set above.
+    const seven = inputs.find((el) => el.value === '7');
+    expect(seven).toBeTruthy();
+
+    fireEvent.change(seven, { target: { value: '' } });
+    expect(seven.value).toBe('');
+
+    fireEvent.blur(seven);
+    expect(seven.value).toBe('0');
+  });
+
+  test('"Apply" sets every topic to the chosen value', () => {
+    renderModal();
+
+    const applyAllInput = screen.getByLabelText('Apply same goal to all topics');
+    fireEvent.change(applyAllInput, { target: { value: '6' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+    // All per-topic inputs should now read 6.
+    const sixes = screen.getAllByRole('spinbutton').filter((el) => el.value === '6');
+    expect(sixes.length).toBeGreaterThanOrEqual(G3_TOPICS.length);
+  });
+
+  test('Save calls onSave with parsed integer targets and selected grade', async () => {
+    const onSave = jest.fn().mockResolvedValue(undefined);
+    const onClose = jest.fn();
+    renderModal({ onSave, onClose });
+
+    fireEvent.click(screen.getByRole('button', { name: /save goals/i }));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    const arg = onSave.mock.calls[0][0];
+    expect(arg.grade).toBe('G3');
+    G3_TOPICS.forEach((topic) => {
+      expect(arg.targets[topic]).toBe(4);
+    });
+    Object.values(arg.targets).forEach((v) => expect(typeof v).toBe('number'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  test('switching to G4 reveals G4 topics', () => {
+    renderModal();
+    const gradeSelect = screen.getAllByRole('combobox')[0];
+    fireEvent.change(gradeSelect, { target: { value: 'G4' } });
+
+    expect(screen.getByText('Operations & Algebraic Thinking')).toBeInTheDocument();
+    expect(screen.getByText('Base Ten')).toBeInTheDocument();
+  });
+
+  test('shows the supplied student count in the header', () => {
+    renderModal({ studentCount: 5 });
+    const modal = screen.getByTestId('modal');
+    expect(within(modal).getByText(/5 students/i)).toBeInTheDocument();
+  });
+
+  test('singular "1 student" for a single student', () => {
+    renderModal({ studentCount: 1 });
+    const modal = screen.getByTestId('modal');
+    expect(within(modal).getByText(/1 student\b/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/portal/__tests__/SubtopicsFocusModal.test.js
+++ b/src/components/portal/__tests__/SubtopicsFocusModal.test.js
@@ -1,0 +1,166 @@
+// Tests for the shared SubtopicsFocusModal used by both ClassDetailPanel
+// and StudentsSection. Covers:
+//   - Rendering with student name and current grade
+//   - Selecting/clearing subtopics
+//   - Save warning when student is unassigned (classId missing)
+//   - onSaved callback receives the updated allowedSubtopicsByTopic map
+const React = require('react');
+const { render, screen, fireEvent, waitFor } = require('@testing-library/react');
+
+const mockUpdateDoc = jest.fn().mockResolvedValue(undefined);
+const mockGetDoc = jest.fn().mockResolvedValue({ exists: () => false, data: () => ({}) });
+
+jest.mock('firebase/firestore', () => ({
+  getFirestore: jest.fn(() => ({})),
+  doc: jest.fn(() => ({})),
+  getDoc: (...args) => mockGetDoc(...args),
+  updateDoc: (...args) => mockUpdateDoc(...args),
+}));
+
+jest.mock('../../ui/ModalWrapper', () => {
+  const React = require('react');
+  return function MockModalWrapper({ isOpen, children }) {
+    if (!isOpen) return null;
+    return React.createElement('div', { 'data-testid': 'modal' }, children);
+  };
+});
+
+// Provide deterministic subtopic data for tests.
+jest.mock('../../../utils/subtopicUtils', () => ({
+  __esModule: true,
+  getSubtopicsForTopic: jest.fn(),
+}));
+
+const subtopicUtils = require('../../../utils/subtopicUtils');
+const SubtopicsFocusModal = require('../SubtopicsFocusModal').default;
+
+const baseStudent = {
+  id: 'student-1',
+  classId: 'class-1',
+  grade: 'G3',
+  name: 'Ada Lovelace',
+};
+
+const renderModal = (overrides = {}) =>
+  render(
+    React.createElement(SubtopicsFocusModal, {
+      isOpen: true,
+      onClose: jest.fn(),
+      student: baseStudent,
+      classId: 'class-1',
+      initialAllowedSubtopicsByTopic: {},
+      onSaved: jest.fn(),
+      ...overrides,
+    })
+  );
+
+describe('SubtopicsFocusModal', () => {
+  beforeEach(() => {
+    mockUpdateDoc.mockClear();
+    mockGetDoc.mockClear();
+    mockGetDoc.mockResolvedValue({ exists: () => false, data: () => ({}) });
+    subtopicUtils.getSubtopicsForTopic.mockImplementation((topic) => {
+      if (topic === 'Multiplication') return ['Times tables', 'Word problems', 'Arrays'];
+      return [];
+    });
+  });
+
+  test('renders with the student name and starting grade', () => {
+    renderModal();
+    expect(screen.getByText(/Ada Lovelace/i)).toBeInTheDocument();
+    const gradeSelect = screen.getAllByRole('combobox')[0];
+    expect(gradeSelect.value).toBe('G3');
+  });
+
+  test('toggling subtopics updates the selection counter', () => {
+    renderModal();
+
+    // Multiplication is the first G3 topic — its subtopics are mocked above.
+    const checkboxes = screen.getAllByRole('checkbox');
+    expect(checkboxes.length).toBeGreaterThan(0);
+
+    fireEvent.click(checkboxes[0]);
+    expect(screen.getByText('1 selected')).toBeInTheDocument();
+
+    fireEvent.click(checkboxes[1]);
+    expect(screen.getByText('2 selected')).toBeInTheDocument();
+  });
+
+  test('Select all / Clear buttons toggle every subtopic', () => {
+    renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /select all/i }));
+    // The "Select all" button text matches as well, but the badge will display "3 selected".
+    expect(screen.getByText('3 selected')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /clear/i }));
+    expect(screen.queryByText(/selected/i)).not.toBeInTheDocument();
+  });
+
+  test('Save persists selected subtopics for the chosen topic and notifies parent', async () => {
+    const onSaved = jest.fn();
+    const onClose = jest.fn();
+    renderModal({ onSaved, onClose });
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[0]); // Times tables
+    fireEvent.click(checkboxes[2]); // Arrays
+
+    fireEvent.click(screen.getByRole('button', { name: /save focus/i }));
+
+    await waitFor(() => expect(mockUpdateDoc).toHaveBeenCalledTimes(1));
+    const [, payload] = mockUpdateDoc.mock.calls[0];
+    expect(payload).toEqual({
+      allowedSubtopicsByTopic: { Multiplication: ['Times tables', 'Arrays'] },
+    });
+
+    await waitFor(() => expect(onSaved).toHaveBeenCalled());
+    expect(onSaved.mock.calls[0][0]).toEqual({
+      Multiplication: ['Times tables', 'Arrays'],
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  test('saving with no selections strips the topic from the allow-list', async () => {
+    // Pre-existing focus has Multiplication restricted; saving with no selection
+    // should remove Multiplication entirely so all subtopics are allowed.
+    mockGetDoc.mockResolvedValue({
+      exists: () => true,
+      data: () => ({
+        allowedSubtopicsByTopic: { Multiplication: ['Times tables'] },
+      }),
+    });
+
+    renderModal({
+      initialAllowedSubtopicsByTopic: { Multiplication: ['Times tables'] },
+    });
+
+    // Clear all, then save.
+    fireEvent.click(screen.getByRole('button', { name: /clear/i }));
+    fireEvent.click(screen.getByRole('button', { name: /save focus/i }));
+
+    await waitFor(() => expect(mockUpdateDoc).toHaveBeenCalled());
+    const [, payload] = mockUpdateDoc.mock.calls[0];
+    expect(payload.allowedSubtopicsByTopic).toEqual({});
+  });
+
+  test('refuses to save when student has no class and shows an inline warning', async () => {
+    const onSaved = jest.fn();
+    renderModal({
+      classId: null,
+      student: { ...baseStudent, classId: null },
+      onSaved,
+    });
+
+    // The warning copy is rendered immediately for unassigned students.
+    expect(
+      screen.getByText(/not assigned to a class yet/i)
+    ).toBeInTheDocument();
+
+    const saveBtn = screen.getByRole('button', { name: /save focus/i });
+    expect(saveBtn).toBeDisabled();
+
+    expect(mockUpdateDoc).not.toHaveBeenCalled();
+    expect(onSaved).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/portal/__tests__/SubtopicsFocusModal.test.js
+++ b/src/components/portal/__tests__/SubtopicsFocusModal.test.js
@@ -7,14 +7,14 @@
 const React = require('react');
 const { render, screen, fireEvent, waitFor } = require('@testing-library/react');
 
-const mockUpdateDoc = jest.fn().mockResolvedValue(undefined);
+const mockSetDoc = jest.fn().mockResolvedValue(undefined);
 const mockGetDoc = jest.fn().mockResolvedValue({ exists: () => false, data: () => ({}) });
 
 jest.mock('firebase/firestore', () => ({
   getFirestore: jest.fn(() => ({})),
   doc: jest.fn(() => ({})),
   getDoc: (...args) => mockGetDoc(...args),
-  updateDoc: (...args) => mockUpdateDoc(...args),
+  setDoc: (...args) => mockSetDoc(...args),
 }));
 
 jest.mock('../../ui/ModalWrapper', () => {
@@ -56,7 +56,7 @@ const renderModal = (overrides = {}) =>
 
 describe('SubtopicsFocusModal', () => {
   beforeEach(() => {
-    mockUpdateDoc.mockClear();
+    mockSetDoc.mockClear();
     mockGetDoc.mockClear();
     mockGetDoc.mockResolvedValue({ exists: () => false, data: () => ({}) });
     subtopicUtils.getSubtopicsForTopic.mockImplementation((topic) => {
@@ -108,11 +108,14 @@ describe('SubtopicsFocusModal', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /save focus/i }));
 
-    await waitFor(() => expect(mockUpdateDoc).toHaveBeenCalledTimes(1));
-    const [, payload] = mockUpdateDoc.mock.calls[0];
+    await waitFor(() => expect(mockSetDoc).toHaveBeenCalledTimes(1));
+    const [, payload, options] = mockSetDoc.mock.calls[0];
     expect(payload).toEqual({
       allowedSubtopicsByTopic: { Multiplication: ['Times tables', 'Arrays'] },
     });
+    // setDoc must use merge so we don't clobber other enrollment fields and
+    // we don't fail when the doc is missing (legacy enrollments).
+    expect(options).toEqual({ merge: true });
 
     await waitFor(() => expect(onSaved).toHaveBeenCalled());
     expect(onSaved.mock.calls[0][0]).toEqual({
@@ -139,9 +142,29 @@ describe('SubtopicsFocusModal', () => {
     fireEvent.click(screen.getByRole('button', { name: /clear/i }));
     fireEvent.click(screen.getByRole('button', { name: /save focus/i }));
 
-    await waitFor(() => expect(mockUpdateDoc).toHaveBeenCalled());
-    const [, payload] = mockUpdateDoc.mock.calls[0];
+    await waitFor(() => expect(mockSetDoc).toHaveBeenCalled());
+    const [, payload] = mockSetDoc.mock.calls[0];
     expect(payload.allowedSubtopicsByTopic).toEqual({});
+  });
+
+  test('save still succeeds when the enrollment doc does not exist yet', async () => {
+    // Missing legacy enrollment — getDoc returns exists=false. The component must
+    // setDoc-with-merge instead of updateDoc, otherwise saving would throw.
+    mockGetDoc.mockResolvedValue({ exists: () => false, data: () => ({}) });
+    const onSaved = jest.fn();
+    renderModal({ onSaved, initialAllowedSubtopicsByTopic: {} });
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[0]); // Times tables
+    fireEvent.click(screen.getByRole('button', { name: /save focus/i }));
+
+    await waitFor(() => expect(mockSetDoc).toHaveBeenCalledTimes(1));
+    const [, payload, options] = mockSetDoc.mock.calls[0];
+    expect(payload).toEqual({
+      allowedSubtopicsByTopic: { Multiplication: ['Times tables'] },
+    });
+    expect(options).toEqual({ merge: true });
+    await waitFor(() => expect(onSaved).toHaveBeenCalled());
   });
 
   test('refuses to save when student has no class and shows an inline warning', async () => {
@@ -160,7 +183,7 @@ describe('SubtopicsFocusModal', () => {
     const saveBtn = screen.getByRole('button', { name: /save focus/i });
     expect(saveBtn).toBeDisabled();
 
-    expect(mockUpdateDoc).not.toHaveBeenCalled();
+    expect(mockSetDoc).not.toHaveBeenCalled();
     expect(onSaved).not.toHaveBeenCalled();
   });
 });

--- a/src/components/portal/sections/ClassDetailPanel.js
+++ b/src/components/portal/sections/ClassDetailPanel.js
@@ -1,14 +1,14 @@
 import React, { useMemo, useState, useEffect, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { X, Users, Calendar, BookOpen, Plus, UserMinus, RefreshCw, Target, AlertCircle, GraduationCap, Link2, Copy, RefreshCcw, CheckCircle } from 'lucide-react';
-import { formatDate, getTopicsForGrade, getAppId } from '../../../utils/common_utils';
+import { formatDate, getAppId } from '../../../utils/common_utils';
 import { getFirestore, doc, getDoc, updateDoc, arrayUnion, arrayRemove } from 'firebase/firestore';
 import { getAuth } from 'firebase/auth';
-import { getSubtopicsForTopic } from '../../../utils/subtopicUtils';
 import { getTeacherIds } from '../../../utils/classHelpers';
 import { USER_ROLES } from '../../../utils/userRoles';
 import { getStudentDisplayName, getStudentShortId } from '../../../utils/studentName';
 import ModalWrapper from '../../ui/ModalWrapper';
+import SubtopicsFocusModal from '../SubtopicsFocusModal';
 
 const ClassDetailPanel = ({
   classItem,
@@ -32,10 +32,6 @@ const ClassDetailPanel = ({
   const [enrollmentReloadTrigger, setEnrollmentReloadTrigger] = useState(0);
   const [showSubtopicsModal, setShowSubtopicsModal] = useState(false);
   const [selectedStudentForSubtopics, setSelectedStudentForSubtopics] = useState(null);
-  const [subtopicGrade, setSubtopicGrade] = useState('G3');
-  const [subtopicTopic, setSubtopicTopic] = useState('');
-  const [selectedSubtopics, setSelectedSubtopics] = useState([]);
-  const [savingSubtopics, setSavingSubtopics] = useState(false);
 
   // Invite state
   const [showInviteModal, setShowInviteModal] = useState(false);
@@ -259,80 +255,19 @@ const ClassDetailPanel = ({
   };
 
   const handleOpenSubtopicsModal = (student) => {
-    const grade = student.grade || 'G3';
-    const topics = getTopicsForGrade(grade);
-    const enrollment = enrollments[student.id];
-    const currentRestrictions = enrollment?.allowedSubtopicsByTopic || {};
-    
     setSelectedStudentForSubtopics(student);
-    setSubtopicGrade(grade);
-    setSubtopicTopic(topics[0] || '');
-    setSelectedSubtopics(currentRestrictions[topics[0]] || []);
     setShowSubtopicsModal(true);
   };
 
-  const handleSubtopicTopicChange = (topicName) => {
-    setSubtopicTopic(topicName);
-    const enrollment = enrollments[selectedStudentForSubtopics.id];
-    const currentRestrictions = enrollment?.allowedSubtopicsByTopic || {};
-    setSelectedSubtopics(currentRestrictions[topicName] || []);
-  };
-
-  const handleSubtopicToggle = (subtopic) => {
-    setSelectedSubtopics((prev) => {
-      if (prev.includes(subtopic)) {
-        return prev.filter((s) => s !== subtopic);
-      } else {
-        return [...prev, subtopic];
-      }
-    });
-  };
-
-  const handleSaveSubtopics = async () => {
-    if (!selectedStudentForSubtopics || !subtopicTopic) return;
-
-    setSavingSubtopics(true);
-    try {
-      const enrollmentId = `${classId}__${selectedStudentForSubtopics.id}`;
-      const enrollmentRef = doc(db, 'artifacts', appId, 'classStudents', enrollmentId);
-      
-      // Get current restrictions
-      const enrollmentSnap = await getDoc(enrollmentRef);
-      const currentData = enrollmentSnap.exists() ? enrollmentSnap.data() : {};
-      const currentRestrictions = currentData.allowedSubtopicsByTopic || {};
-
-      // Update restrictions for this topic
-      const updatedRestrictions = {
-        ...currentRestrictions,
-        [subtopicTopic]: selectedSubtopics,
-      };
-
-      // Remove topic entry if no subtopics selected (allow all)
-      if (selectedSubtopics.length === 0) {
-        delete updatedRestrictions[subtopicTopic];
-      }
-
-      // Update enrollment document
-      await updateDoc(enrollmentRef, {
-        allowedSubtopicsByTopic: updatedRestrictions,
-      });
-
-      // Update local state
-      setEnrollments((prev) => ({
-        ...prev,
-        [selectedStudentForSubtopics.id]: {
-          allowedSubtopicsByTopic: updatedRestrictions,
-        },
-      }));
-
-      setShowSubtopicsModal(false);
-      setStatus({ type: 'success', message: 'Subtopics updated successfully.' });
-    } catch (error) {
-      console.error('Error saving subtopics:', error);
-      setStatus({ type: 'error', message: 'Failed to save subtopics.' });
-    } finally {
-      setSavingSubtopics(false);
-    }
+  const handleSubtopicsSaved = (updatedAllowed) => {
+    if (!selectedStudentForSubtopics) return;
+    setEnrollments((prev) => ({
+      ...prev,
+      [selectedStudentForSubtopics.id]: {
+        allowedSubtopicsByTopic: updatedAllowed,
+      },
+    }));
+    setStatus({ type: 'success', message: 'Subtopics updated successfully.' });
   };
 
   // Escape key to close
@@ -788,116 +723,18 @@ const ClassDetailPanel = ({
         </ModalWrapper>
       )}
 
-      {/* Subtopics Modal */}
+      {/* Subtopics Modal (shared component) */}
       {showSubtopicsModal && selectedStudentForSubtopics && renderModalInPortal(
-        <ModalWrapper
+        <SubtopicsFocusModal
           isOpen={showSubtopicsModal}
           onClose={() => setShowSubtopicsModal(false)}
-          title="Set Focus Subtopics"
-          size="md"
-        >
-          <div className="px-6 py-5 overflow-y-auto flex-1 space-y-5">
-            <p className="text-sm text-gray-600">
-              {getStudentDisplayName(selectedStudentForSubtopics)}
-            </p>
-
-            <div className="grid grid-cols-1 sm:grid-cols-[auto,1fr] gap-4">
-              <div>
-                <label className="text-sm text-gray-700 font-medium block">Grade</label>
-                <select
-                  value={subtopicGrade}
-                  onChange={(e) => {
-                    const newGrade = e.target.value;
-                    setSubtopicGrade(newGrade);
-                    const topics = getTopicsForGrade(newGrade);
-                    setSubtopicTopic(topics[0] || '');
-                    const enrollment = enrollments[selectedStudentForSubtopics.id];
-                    const currentRestrictions = enrollment?.allowedSubtopicsByTopic || {};
-                    setSelectedSubtopics(currentRestrictions[topics[0]] || []);
-                  }}
-                  className="mt-1 border border-gray-300 rounded-md px-3 py-2 text-sm w-full"
-                >
-                  <option value="G3">G3</option>
-                  <option value="G4">G4</option>
-                </select>
-              </div>
-              <div>
-                <label className="text-sm text-gray-700 font-medium block">Topic</label>
-                <select
-                  value={subtopicTopic}
-                  onChange={(e) => handleSubtopicTopicChange(e.target.value)}
-                  className="mt-1 w-full border border-gray-300 rounded-md px-3 py-2 text-sm"
-                >
-                  {getTopicsForGrade(subtopicGrade).map((topic) => (
-                    <option key={topic} value={topic}>
-                      {topic}
-                    </option>
-                  ))}
-                </select>
-              </div>
-            </div>
-
-            {subtopicTopic && (
-              <div>
-                <label className="text-sm text-gray-700 font-medium mb-2 block">
-                  Select specific subtopics to focus on (leave empty to include all subtopics):
-                </label>
-                <div className="border border-gray-200 rounded-lg p-3 max-h-72 overflow-y-auto bg-gray-50/60">
-                  {(() => {
-                    const subtopics = getSubtopicsForTopic(subtopicTopic, subtopicGrade);
-                    if (subtopics.length === 0) {
-                      return (
-                        <p className="text-sm text-gray-500 italic">
-                          This topic does not have subtopics defined.
-                        </p>
-                      );
-                    }
-                    return (
-                      <div className="space-y-2">
-                        {subtopics.map((subtopic) => (
-                          <label
-                            key={subtopic}
-                            className="flex items-center space-x-2 cursor-pointer hover:bg-white p-2 rounded-md transition-colors"
-                          >
-                            <input
-                              type="checkbox"
-                              checked={selectedSubtopics.includes(subtopic)}
-                              onChange={() => handleSubtopicToggle(subtopic)}
-                              className="h-4 w-4 text-purple-600 focus:ring-purple-500 border-gray-300 rounded"
-                            />
-                            <span className="text-sm text-gray-700">{subtopic}</span>
-                          </label>
-                        ))}
-                      </div>
-                    );
-                  })()}
-                </div>
-                {selectedSubtopics.length > 0 && (
-                  <p className="mt-2 text-xs text-gray-500">
-                    {selectedSubtopics.length} subtopic{selectedSubtopics.length !== 1 ? 's' : ''} selected
-                  </p>
-                )}
-              </div>
-            )}
-          </div>
-
-          <div className="px-6 py-4 border-t border-gray-200 flex justify-end space-x-2 bg-gray-50">
-            <button
-              onClick={() => setShowSubtopicsModal(false)}
-              className="px-4 py-2 rounded-md border border-gray-300 hover:bg-white text-sm font-medium text-gray-700"
-              disabled={savingSubtopics}
-            >
-              Cancel
-            </button>
-            <button
-              onClick={handleSaveSubtopics}
-              disabled={savingSubtopics}
-              className="px-4 py-2 rounded-md bg-blue-600 text-white hover:bg-blue-700 text-sm font-medium disabled:opacity-50"
-            >
-              {savingSubtopics ? 'Saving...' : 'Save'}
-            </button>
-          </div>
-        </ModalWrapper>
+          student={selectedStudentForSubtopics}
+          classId={classId}
+          initialAllowedSubtopicsByTopic={
+            enrollments[selectedStudentForSubtopics.id]?.allowedSubtopicsByTopic || {}
+          }
+          onSaved={handleSubtopicsSaved}
+        />
       )}
     </div>
   );

--- a/src/components/portal/sections/StudentsSection.js
+++ b/src/components/portal/sections/StudentsSection.js
@@ -1,13 +1,15 @@
 import React, { useState, useCallback } from 'react';
 import {
   BarChart3, RefreshCw, Download, Target, Trash2, Eye,
-  ChevronUp, ChevronDown, CheckCircle, X
+  ChevronUp, ChevronDown, CheckCircle, Crosshair
 } from 'lucide-react';
-import { getFirestore, doc, writeBatch } from 'firebase/firestore';
-import { formatDate, normalizeDate, getTopicsForGrade, calculateTopicProgressForRange, getTodayDateString } from '../../../utils/common_utils';
+import { getFirestore, doc, writeBatch, getDoc } from 'firebase/firestore';
+import { formatDate, normalizeDate, calculateTopicProgressForRange, getTodayDateString, getAppId } from '../../../utils/common_utils';
 import { getStudentDisplayName, getStudentShortId } from '../../../utils/studentName';
 import ConfirmationModal from '../../ui/ConfirmationModal';
 import useConfirmation from '../../../hooks/useConfirmation';
+import GoalsModal from '../GoalsModal';
+import SubtopicsFocusModal from '../SubtopicsFocusModal';
 
 const fieldMap = {
   'grade': 'grade',
@@ -26,6 +28,9 @@ const StudentsSection = ({ students, loading, error, onRefresh, appId }) => {
   const [goalGrade, setGoalGrade] = useState('G3');
   const [goalTargets, setGoalTargets] = useState({});
   const [goalStudentIds, setGoalStudentIds] = useState([]);
+  const [focusStudent, setFocusStudent] = useState(null);
+  const [focusInitialAllowed, setFocusInitialAllowed] = useState({});
+  const [focusLoadingStudentId, setFocusLoadingStudentId] = useState(null);
   const [viewingStudent, setViewingStudent] = useState(null);
   const [startDate, setStartDate] = useState(getTodayDateString());
   const [endDate, setEndDate] = useState(getTodayDateString());
@@ -158,13 +163,7 @@ const StudentsSection = ({ students, loading, error, onRefresh, appId }) => {
   // Goals Logic
   const openGoalsModalForStudent = (student) => {
     const grade = student.grade || 'G3';
-    const topics = getTopicsForGrade(grade);
     const current = student.dailyGoalsByGrade?.[grade] || {};
-    
-    // Fill in defaults if missing
-    topics.forEach(t => {
-      if (current[t] === undefined) current[t] = 4;
-    });
 
     setGoalGrade(grade);
     setGoalTargets(current);
@@ -174,52 +173,64 @@ const StudentsSection = ({ students, loading, error, onRefresh, appId }) => {
 
   const openGoalsModalForSelected = () => {
     const ids = Array.from(selectedStudents);
-    const grade = 'G3'; // Default to G3 for bulk
-    const topics = getTopicsForGrade(grade);
-    const current = {};
-    topics.forEach(t => current[t] = 4);
-    
+    const grade = 'G3';
+
     setGoalGrade(grade);
-    setGoalTargets(current);
+    setGoalTargets({});
     setGoalStudentIds(ids);
     setShowGoalsModal(true);
   };
 
-  const handleGoalGradeChange = (grade) => {
-    const topics = getTopicsForGrade(grade);
-    const next = { ...goalTargets };
-    topics.forEach(t => {
-      if (next[t] === undefined) next[t] = 4;
+  const saveGoals = async ({ grade, targets }) => {
+    if (!appId) {
+      throw new Error('App ID is missing');
+    }
+    const batch = writeBatch(db);
+
+    goalStudentIds.forEach(studentId => {
+      const studentRef = doc(db, 'artifacts', appId, 'users', studentId, 'math_whiz_data', 'profile');
+      const updateData = {
+        [`dailyGoalsByGrade.${grade}`]: targets,
+      };
+      batch.update(studentRef, updateData);
     });
-    setGoalGrade(grade);
-    setGoalTargets(next);
+
+    await batch.commit();
+    if (onRefresh) onRefresh();
   };
 
-  const saveGoals = async () => {
-    if (!appId) {
-      console.error('App ID is missing');
+  // Focus logic
+  const openFocusModalForStudent = async (student) => {
+    if (!student) return;
+
+    if (!student.classId) {
+      // No class to scope focus to; still open the modal so we can show a hint.
+      setFocusInitialAllowed({});
+      setFocusStudent(student);
       return;
     }
-    try {
-      const batch = writeBatch(db);
-      
-      goalStudentIds.forEach(studentId => {
-        // Use the correct path for the new data model
-        const studentRef = doc(db, 'artifacts', appId, 'users', studentId, 'math_whiz_data', 'profile');
-        // We need to update the specific grade goals
-        const updateData = {
-          [`dailyGoalsByGrade.${goalGrade}`]: goalTargets
-        };
-        batch.update(studentRef, updateData);
-      });
 
-      await batch.commit();
-      setShowGoalsModal(false);
-      if (onRefresh) onRefresh();
-    } catch (error) {
-      console.error('Error saving goals:', error);
-      alert('Failed to save goals.');
+    setFocusLoadingStudentId(student.id);
+    try {
+      const enrollmentId = `${student.classId}__${student.id}`;
+      const enrollmentRef = doc(db, 'artifacts', getAppId(), 'classStudents', enrollmentId);
+      const snap = await getDoc(enrollmentRef);
+      const data = snap.exists() ? (snap.data().allowedSubtopicsByTopic || {}) : {};
+      setFocusInitialAllowed(data);
+      setFocusStudent(student);
+    } catch (err) {
+      console.error('Error loading focus data:', err);
+      // Still open modal with empty initial state, save will overwrite the chosen topic.
+      setFocusInitialAllowed({});
+      setFocusStudent(student);
+    } finally {
+      setFocusLoadingStudentId(null);
     }
+  };
+
+  const closeFocusModal = () => {
+    setFocusStudent(null);
+    setFocusInitialAllowed({});
   };
 
   const sortedStudents = getSortedStudents();
@@ -732,16 +743,29 @@ const StudentsSection = ({ students, loading, error, onRefresh, appId }) => {
                     <button
                       onClick={() => setViewingStudent(student)}
                       className="text-blue-600 hover:text-blue-900 inline-flex items-center"
-                      title="View Details"
+                      title="View details"
                     >
                       <Eye className="w-4 h-4" />
                     </button>
                     <button
                       onClick={() => openGoalsModalForStudent(student)}
                       className="text-purple-600 hover:text-purple-900 inline-flex items-center"
-                      title="Set Goals"
+                      title="Set daily goals"
                     >
                       <Target className="w-4 h-4" />
+                    </button>
+                    <button
+                      onClick={() => openFocusModalForStudent(student)}
+                      disabled={focusLoadingStudentId === student.id || !student.classId}
+                      className="text-emerald-600 hover:text-emerald-900 inline-flex items-center disabled:opacity-40 disabled:cursor-not-allowed"
+                      title={
+                        student.classId
+                          ? 'Set focus subtopics'
+                          : 'Assign student to a class to set focus subtopics'
+                      }
+                      aria-label="Set focus subtopics"
+                    >
+                      <Crosshair className="w-4 h-4" />
                     </button>
                   </td>
                 </tr>
@@ -816,48 +840,26 @@ const StudentsSection = ({ students, loading, error, onRefresh, appId }) => {
 
       <ConfirmationModal {...confirmationProps} />
 
-      {/* Goals Modal */}
-      {showGoalsModal && (
-        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg shadow-lg w-full max-w-2xl p-6">
-            <div className="flex items-center justify-between mb-4">
-              <h3 className="text-lg font-semibold text-gray-900">Set Daily Goals</h3>
-              <button onClick={() => setShowGoalsModal(false)} className="text-gray-500 hover:text-gray-700">
-                <X className="w-5 h-5" />
-              </button>
-            </div>
-            <div className="mb-4 flex items-center space-x-4">
-              <label className="text-sm text-gray-700">Grade:</label>
-              <select
-                value={goalGrade}
-                onChange={(e) => handleGoalGradeChange(e.target.value)}
-                className="border rounded px-2 py-1"
-              >
-                <option value="G3">G3</option>
-                <option value="G4">G4</option>
-              </select>
-              <span className="text-sm text-gray-500">Applying to {goalStudentIds.length} student(s)</span>
-            </div>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 max-h-[60vh] overflow-y-auto">
-              {getTopicsForGrade(goalGrade).map(topic => (
-                <div key={topic} className="flex items-center justify-between border rounded px-3 py-2">
-                  <span className="text-sm text-gray-700 mr-3 truncate" title={topic}>{topic}</span>
-                  <input
-                    type="number"
-                    min="0"
-                    value={goalTargets[topic] ?? 4}
-                    onChange={(e) => setGoalTargets(prev => ({ ...prev, [topic]: parseInt(e.target.value, 10) || 0 }))}
-                    className="w-20 border rounded px-2 py-1 text-sm"
-                  />
-                </div>
-              ))}
-            </div>
-            <div className="mt-6 text-right space-x-2">
-              <button onClick={() => setShowGoalsModal(false)} className="px-4 py-2 rounded border hover:bg-gray-50">Cancel</button>
-              <button onClick={saveGoals} className="px-4 py-2 rounded bg-purple-600 text-white hover:bg-purple-700">Save</button>
-            </div>
-          </div>
-        </div>
+      <GoalsModal
+        isOpen={showGoalsModal}
+        onClose={() => setShowGoalsModal(false)}
+        initialGrade={goalGrade}
+        initialTargets={goalTargets}
+        studentCount={goalStudentIds.length}
+        onSave={saveGoals}
+      />
+
+      {focusStudent && (
+        <SubtopicsFocusModal
+          isOpen={!!focusStudent}
+          onClose={closeFocusModal}
+          student={focusStudent}
+          classId={focusStudent.classId}
+          initialAllowedSubtopicsByTopic={focusInitialAllowed}
+          onSaved={() => {
+            if (onRefresh) onRefresh();
+          }}
+        />
       )}
     </div>
   );

--- a/src/components/portal/sections/StudentsSection.js
+++ b/src/components/portal/sections/StudentsSection.js
@@ -4,7 +4,7 @@ import {
   ChevronUp, ChevronDown, CheckCircle, Crosshair
 } from 'lucide-react';
 import { getFirestore, doc, writeBatch, getDoc } from 'firebase/firestore';
-import { formatDate, normalizeDate, calculateTopicProgressForRange, getTodayDateString, getAppId } from '../../../utils/common_utils';
+import { formatDate, normalizeDate, calculateTopicProgressForRange, getTodayDateString } from '../../../utils/common_utils';
 import { getStudentDisplayName, getStudentShortId } from '../../../utils/studentName';
 import ConfirmationModal from '../../ui/ConfirmationModal';
 import useConfirmation from '../../../hooks/useConfirmation';
@@ -204,7 +204,8 @@ const StudentsSection = ({ students, loading, error, onRefresh, appId }) => {
     if (!student) return;
 
     if (!student.classId) {
-      // No class to scope focus to; still open the modal so we can show a hint.
+      // No class — open the modal anyway so the user sees the inline hint
+      // explaining that the student must be assigned to a class first.
       setFocusInitialAllowed({});
       setFocusStudent(student);
       return;
@@ -213,7 +214,7 @@ const StudentsSection = ({ students, loading, error, onRefresh, appId }) => {
     setFocusLoadingStudentId(student.id);
     try {
       const enrollmentId = `${student.classId}__${student.id}`;
-      const enrollmentRef = doc(db, 'artifacts', getAppId(), 'classStudents', enrollmentId);
+      const enrollmentRef = doc(db, 'artifacts', appId, 'classStudents', enrollmentId);
       const snap = await getDoc(enrollmentRef);
       const data = snap.exists() ? (snap.data().allowedSubtopicsByTopic || {}) : {};
       setFocusInitialAllowed(data);
@@ -756,7 +757,7 @@ const StudentsSection = ({ students, loading, error, onRefresh, appId }) => {
                     </button>
                     <button
                       onClick={() => openFocusModalForStudent(student)}
-                      disabled={focusLoadingStudentId === student.id || !student.classId}
+                      disabled={focusLoadingStudentId === student.id}
                       className="text-emerald-600 hover:text-emerald-900 inline-flex items-center disabled:opacity-40 disabled:cursor-not-allowed"
                       title={
                         student.classId


### PR DESCRIPTION
## Summary
Refactored modal components used in the teacher portal to improve code reusability and maintainability. Extracted `SubtopicsFocusModal` and `GoalsModal` into standalone, reusable components that can be shared across multiple sections of the application.

## Key Changes

- **New `SubtopicsFocusModal` component** (`src/components/portal/SubtopicsFocusModal.js`)
  - Extracted from inline modal logic in `ClassDetailPanel`
  - Allows teachers to restrict which subtopics a student practices for a given topic
  - Handles grade/topic selection, subtopic toggling, and persistence to Firestore
  - Shows warning when student is not assigned to a class
  - Accepts `initialAllowedSubtopicsByTopic` and calls `onSaved` callback with updated restrictions
  - Now used by both `ClassDetailPanel` and `StudentsSection`

- **New `GoalsModal` component** (`src/components/portal/GoalsModal.js`)
  - Extracted from inline modal logic in `StudentsSection`
  - Allows teachers to set daily question targets per topic for one or more students
  - Supports bulk "Apply to all topics" functionality
  - Handles grade switching with proper topic list updates
  - Normalizes and validates numeric inputs (clamps to 0+, handles empty fields)
  - Accepts `onSave` callback that receives `{ grade, targets }` with integer values

- **Updated `ClassDetailPanel`** (`src/components/portal/sections/ClassDetailPanel.js`)
  - Removed inline subtopics modal implementation (~80 lines)
  - Now uses `SubtopicsFocusModal` component
  - Simplified state management by delegating to the modal component
  - Maintains local enrollment state updates via `handleSubtopicsSaved` callback

- **Updated `StudentsSection`** (`src/components/portal/sections/StudentsSection.js`)
  - Removed inline goals modal implementation
  - Now uses `GoalsModal` component for both single-student and bulk operations
  - Removed inline subtopics modal implementation
  - Now uses `SubtopicsFocusModal` component for per-student focus settings
  - Refactored `saveGoals` to work with the new modal's callback pattern
  - Added `openFocusModalForStudent` to load enrollment data before opening modal

- **Fixed number input behavior** in `GenerateQuestionsModal` and `ImageGenerationModal`
  - Changed `count` state from number to string to allow clearing the field during typing
  - Prevents clamping on every keystroke (was preventing users from clearing and retyping)
  - Blur handler now properly validates and clamps to min/max bounds
  - Added comprehensive tests for this input reset behavior

- **Added comprehensive test suites**
  - `SubtopicsFocusModal.test.js`: Tests rendering, selection, save, and class assignment validation
  - `GoalsModal.test.js`: Tests per-topic inputs, bulk apply, and save callback
  - `GenerateQuestionsModal.count.test.js`: Tests number input clearing and clamping
  - `ImageGenerationModal.count.test.js`: Tests number input clearing and clamping

## Implementation Details

- Both new modals follow the same pattern: accept initial state, manage local state, and call parent callbacks with normalized data
- `SubtopicsFocusModal` handles Firestore persistence directly; `GoalsModal` delegates to parent via callback
- Number inputs now use string state with validation on blur, allowing users to clear fields without triggering clamping
- Modal components are self-contained and can be reused in different contexts (class detail, student list, etc.)

https://claude.ai/code/session_01PWkz3CNwYyvTguJ8srSDeL