### PR TITLE
Enhance modals with gradient headers and reset buttons

### DIFF
--- a/src/components/GenerateQuestionsModal.js
+++ b/src/components/GenerateQuestionsModal.js
@@ -1,11 +1,12 @@
 import React, { useState, useRef, useCallback } from 'react';
-import { Sparkles, Loader2, AlertCircle } from 'lucide-react';
+import { Sparkles, Loader2, AlertCircle, RotateCcw } from 'lucide-react';
 import ModalWrapper from './ui/ModalWrapper';
 import { getAuth } from 'firebase/auth';
 import { GRADES, VALID_TOPICS_BY_GRADE, QUESTION_TYPES } from '../constants/topics';
 
 const BATCH_SIZE = 25;
 const MAX_QUESTIONS = 15;
+const DEFAULT_COUNT = '10';
 const MAX_ADDITIONAL_INSTRUCTIONS_LENGTH = 500;
 
 const GENERATABLE_TYPES = [
@@ -18,7 +19,7 @@ const GenerateQuestionsModal = ({ isOpen, onClose, onGenerated }) => {
   const [grade, setGrade] = useState(GRADES.G3);
   const [topic, setTopic] = useState('');
   const [questionTypes, setQuestionTypes] = useState([QUESTION_TYPES.MULTIPLE_CHOICE]);
-  const [count, setCount] = useState('10');
+  const [count, setCount] = useState(DEFAULT_COUNT);
   const [additionalInstructions, setAdditionalInstructions] = useState('');
   const [generating, setGenerating] = useState(false);
   const [progress, setProgress] = useState({ completed: 0, total: 0 });
@@ -128,7 +129,28 @@ const GenerateQuestionsModal = ({ isOpen, onClose, onGenerated }) => {
   };
 
   return (
-    <ModalWrapper isOpen={isOpen} onClose={handleCancel} title="Generate Questions with AI" size="sm">
+    <ModalWrapper isOpen={isOpen} onClose={handleCancel} title="" size="sm" hideCloseButton>
+      <div className="bg-gradient-to-r from-purple-600 to-pink-600 text-white px-6 py-5 flex items-center justify-between">
+        <div className="flex items-center space-x-3">
+          <div className="bg-white/20 rounded-full p-2">
+            <Sparkles className="h-5 w-5" />
+          </div>
+          <div>
+            <h2 className="text-lg font-semibold">Generate questions with AI</h2>
+            <p className="text-sm text-purple-100">
+              Create new practice questions for any topic in seconds.
+            </p>
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={handleCancel}
+          className="text-white/80 hover:text-white text-2xl leading-none"
+          aria-label="Close"
+        >
+          ×
+        </button>
+      </div>
       <div className="p-6">
         {/* Error */}
         {error && (
@@ -202,26 +224,39 @@ const GenerateQuestionsModal = ({ isOpen, onClose, onGenerated }) => {
             <label className="block text-sm font-medium text-gray-700 mb-1">
               Number of Questions
             </label>
-            <input
-              type="number"
-              value={count}
-              onChange={(e) => setCount(e.target.value)}
-              onBlur={() => {
-                const parsed = parseInt(count, 10);
-                if (!Number.isFinite(parsed) || parsed < 1) {
-                  setCount('1');
-                } else if (parsed > MAX_QUESTIONS) {
-                  setCount(String(MAX_QUESTIONS));
-                } else {
-                  setCount(String(parsed));
-                }
-              }}
-              disabled={generating}
-              min={1}
-              max={MAX_QUESTIONS}
-              className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
-            />
-            <p className="text-xs text-gray-500 mt-1">Maximum {MAX_QUESTIONS} questions per generation</p>
+            <div className="flex items-stretch gap-2">
+              <input
+                type="number"
+                value={count}
+                onChange={(e) => setCount(e.target.value)}
+                onBlur={() => {
+                  const parsed = parseInt(count, 10);
+                  if (!Number.isFinite(parsed) || parsed < 1) {
+                    setCount('1');
+                  } else if (parsed > MAX_QUESTIONS) {
+                    setCount(String(MAX_QUESTIONS));
+                  } else {
+                    setCount(String(parsed));
+                  }
+                }}
+                disabled={generating}
+                min={1}
+                max={MAX_QUESTIONS}
+                className="flex-1 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+              />
+              <button
+                type="button"
+                onClick={() => setCount(DEFAULT_COUNT)}
+                disabled={generating || count === DEFAULT_COUNT}
+                className="inline-flex items-center px-3 py-2 text-sm font-medium text-gray-600 bg-white border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                title={`Reset to default (${DEFAULT_COUNT})`}
+                aria-label="Reset to default"
+              >
+                <RotateCcw className="h-4 w-4 mr-1" />
+                Reset
+              </button>
+            </div>
+            <p className="text-xs text-gray-500 mt-1">Maximum {MAX_QUESTIONS} questions per generation (default: {DEFAULT_COUNT}).</p>
           </div>
 
           {/* Additional Instructions */}

--- a/src/components/ImageGenerationModal.js
+++ b/src/components/ImageGenerationModal.js
@@ -1,10 +1,11 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { X, ChevronLeft, ChevronRight, Edit2, Check, Loader2, AlertCircle } from 'lucide-react';
+import { X, ChevronLeft, ChevronRight, Edit2, Check, Loader2, AlertCircle, Sparkles, RotateCcw } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
 
 const APP_ID = 'default-app-id';
 const POLL_INTERVAL = 2000; // Poll every 2 seconds
 const JOB_TIMEOUT_MS = 12 * 60 * 1000; // 12 minutes (server timeout is 10m)
+const DEFAULT_COUNT = '3';
 
 const ImageGenerationModal = ({ isOpen, onClose, onSuccess }) => {
   const { user } = useAuth();
@@ -51,7 +52,7 @@ const ImageGenerationModal = ({ isOpen, onClose, onSuccess }) => {
       setStep(1);
       setTheme('');
       setThemeDescription('');
-      setCount('3');
+      setCount(DEFAULT_COUNT);
       setDescriptions([]);
       setGeneratedImages([]);
       setSelectedIndices([]);
@@ -578,19 +579,25 @@ const ImageGenerationModal = ({ isOpen, onClose, onSuccess }) => {
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50" role="dialog" aria-modal="true">
       <div className="bg-white rounded-lg shadow-xl w-full max-w-4xl max-h-[90vh] overflow-hidden flex flex-col">
         {/* Header */}
-        <div className="flex items-center justify-between p-6 border-b">
-          <div>
-            <h2 className="text-2xl font-bold text-gray-900">Generate Store Images</h2>
-            <p className="text-sm text-gray-600 mt-1">
-              Step {step} of 4: {step === 1 && 'Input Theme'}
-              {step === 2 && 'Review Descriptions'}
-              {step === 3 && 'Select Images'}
-              {step === 4 && 'Review & Confirm'}
-            </p>
+        <div className="bg-gradient-to-r from-indigo-600 to-purple-600 text-white px-6 py-5 flex items-center justify-between">
+          <div className="flex items-center space-x-3">
+            <div className="bg-white/20 rounded-full p-2">
+              <Sparkles className="h-5 w-5" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold">Generate store images</h2>
+              <p className="text-sm text-indigo-100">
+                Step {step} of 4 — {step === 1 && 'Input Theme'}
+                {step === 2 && 'Review Descriptions'}
+                {step === 3 && 'Select Images'}
+                {step === 4 && 'Review & Confirm'}
+              </p>
+            </div>
           </div>
           <button
             onClick={handleClose}
-            className="text-gray-400 hover:text-gray-600 transition-colors"
+            className="text-white/80 hover:text-white transition-colors"
+            aria-label="Close"
           >
             <X className="w-6 h-6" />
           </button>
@@ -689,26 +696,39 @@ const ImageGenerationModal = ({ isOpen, onClose, onSuccess }) => {
                 <label className="block text-sm font-medium text-gray-700 mb-2">
                   Number of Images
                 </label>
-                <input
-                  type="number"
-                  min="1"
-                  max="10"
-                  value={count}
-                  onChange={(e) => setCount(e.target.value)}
-                  onBlur={() => {
-                    const parsed = parseInt(count, 10);
-                    if (!Number.isFinite(parsed) || parsed < 1) {
-                      setCount('1');
-                    } else if (parsed > 10) {
-                      setCount('10');
-                    } else {
-                      setCount(String(parsed));
-                    }
-                  }}
-                  className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                />
+                <div className="flex items-stretch gap-2">
+                  <input
+                    type="number"
+                    min="1"
+                    max="10"
+                    value={count}
+                    onChange={(e) => setCount(e.target.value)}
+                    onBlur={() => {
+                      const parsed = parseInt(count, 10);
+                      if (!Number.isFinite(parsed) || parsed < 1) {
+                        setCount('1');
+                      } else if (parsed > 10) {
+                        setCount('10');
+                      } else {
+                        setCount(String(parsed));
+                      }
+                    }}
+                    className="flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setCount(DEFAULT_COUNT)}
+                    disabled={count === DEFAULT_COUNT}
+                    className="inline-flex items-center px-3 py-2 text-sm font-medium text-gray-600 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                    title={`Reset to default (${DEFAULT_COUNT})`}
+                    aria-label="Reset to default"
+                  >
+                    <RotateCcw className="h-4 w-4 mr-1" />
+                    Reset
+                  </button>
+                </div>
                 <p className="text-xs text-gray-500 mt-1">
-                  How many images to generate (1-10)
+                  How many images to generate (1-10, default: {DEFAULT_COUNT})
                 </p>
               </div>
             </div>

--- a/src/components/__tests__/GenerateQuestionsModal.count.test.js
+++ b/src/components/__tests__/GenerateQuestionsModal.count.test.js
@@ -135,4 +135,57 @@ describe('GenerateQuestionsModal - count input reset behavior', () => {
     expect(payload.count).toBe(4);
     expect(payload.questionTypes).toContain(QUESTION_TYPES.MULTIPLE_CHOICE);
   });
+
+  test('Reset button restores the count to the default (10)', () => {
+    render(
+      React.createElement(GenerateQuestionsModal, {
+        isOpen: true,
+        onClose: jest.fn(),
+        onGenerated: jest.fn(),
+      })
+    );
+
+    const input = findCountInput();
+    expect(input.value).toBe('10');
+
+    fireEvent.change(input, { target: { value: '7' } });
+    expect(input.value).toBe('7');
+
+    fireEvent.click(screen.getByRole('button', { name: /reset to default/i }));
+    expect(input.value).toBe('10');
+  });
+
+  test('Reset button is disabled when count is already at the default', () => {
+    render(
+      React.createElement(GenerateQuestionsModal, {
+        isOpen: true,
+        onClose: jest.fn(),
+        onGenerated: jest.fn(),
+      })
+    );
+
+    const resetBtn = screen.getByRole('button', { name: /reset to default/i });
+    expect(resetBtn).toBeDisabled();
+
+    const input = findCountInput();
+    fireEvent.change(input, { target: { value: '5' } });
+    expect(resetBtn).not.toBeDisabled();
+  });
+
+  test('header shows the friendly title and subtitle copy', () => {
+    render(
+      React.createElement(GenerateQuestionsModal, {
+        isOpen: true,
+        onClose: jest.fn(),
+        onGenerated: jest.fn(),
+      })
+    );
+
+    expect(
+      screen.getByText(/generate questions with ai/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/create new practice questions/i)
+    ).toBeInTheDocument();
+  });
 });

--- a/src/components/__tests__/ImageGenerationModal.count.test.js
+++ b/src/components/__tests__/ImageGenerationModal.count.test.js
@@ -101,4 +101,53 @@ describe('ImageGenerationModal - count input reset behavior', () => {
     fireEvent.change(input, { target: { value: '4' } });
     expect(next).not.toBeDisabled();
   });
+
+  test('Reset button restores the count to the default (3)', () => {
+    render(
+      React.createElement(ImageGenerationModal, {
+        isOpen: true,
+        onClose: jest.fn(),
+        onSuccess: jest.fn(),
+      })
+    );
+
+    const input = findCountInput();
+    expect(input.value).toBe('3');
+
+    fireEvent.change(input, { target: { value: '8' } });
+    expect(input.value).toBe('8');
+
+    fireEvent.click(screen.getByRole('button', { name: /reset to default/i }));
+    expect(input.value).toBe('3');
+  });
+
+  test('Reset button is disabled when count is already at the default', () => {
+    render(
+      React.createElement(ImageGenerationModal, {
+        isOpen: true,
+        onClose: jest.fn(),
+        onSuccess: jest.fn(),
+      })
+    );
+
+    const resetBtn = screen.getByRole('button', { name: /reset to default/i });
+    expect(resetBtn).toBeDisabled();
+
+    const input = findCountInput();
+    fireEvent.change(input, { target: { value: '7' } });
+    expect(resetBtn).not.toBeDisabled();
+  });
+
+  test('header shows the friendly title and step subtitle copy', () => {
+    render(
+      React.createElement(ImageGenerationModal, {
+        isOpen: true,
+        onClose: jest.fn(),
+        onSuccess: jest.fn(),
+      })
+    );
+
+    expect(screen.getByText(/generate store images/i)).toBeInTheDocument();
+    expect(screen.getByText(/step 1 of 4/i)).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
This PR improves the user experience of two AI generation modals (ImageGenerationModal and GenerateQuestionsModal) by adding visually appealing gradient headers and introducing reset buttons for count inputs.

## Key Changes

- **Enhanced Modal Headers**: Replaced plain headers with gradient backgrounds (indigo-to-purple for images, purple-to-pink for questions) featuring icons and improved typography
- **Reset Buttons**: Added reset-to-default buttons next to count inputs in both modals, allowing users to quickly restore the default value (3 for images, 10 for questions)
- **Constants**: Extracted default count values as constants (`DEFAULT_COUNT`) for maintainability
- **Improved Accessibility**: Added proper ARIA labels and titles to new interactive elements
- **Updated Help Text**: Modified helper text to reference the default values
- **Test Coverage**: Added comprehensive tests verifying reset button functionality, disabled states, and header content

## Implementation Details

- The reset button is disabled when the count is already at the default value, preventing unnecessary state updates
- Both modals now use consistent styling patterns with gradient headers and icon badges
- The `RotateCcw` icon from lucide-react provides clear visual indication of the reset action
- Helper text now explicitly mentions the default value for better user guidance

https://claude.ai/code/session_01QwW5i2dpL3NoyqZ3fz7NSP