### PR TITLE
SEO: Fix Math Whiz about page canonicals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# AGENTS.md - math-whiz-app
+
+## Site
+- URL: https://mathwhizapp.kids
+- Purpose: Free adaptive math practice app for 3rd and 4th grade students, teachers, and parents.
+
+## Tech stack
+- React 19 via Create React App / `react-scripts`
+- React Router DOM 7 SPA
+- Firebase Auth + Firestore
+- Netlify hosting with serverless functions and edge functions
+- Tailwind CSS
+
+## SEO-relevant file map
+- Sitemap: `netlify/edge-functions/sitemap.js`, mounted at `/sitemap.xml` from `netlify.toml`
+- Robots.txt: `netlify/edge-functions/robots.js`, mounted at `/robots.txt` from `netlify.toml`
+- Static base head: `public/index.html`
+- Route-specific SEO head: `src/components/about/SeoHead.js`
+- Route-specific edge head injection: `netlify/edge-functions/seo-head.js`
+- SEO page registry: `src/components/about/seoPageConfig.js`
+- Marketing routes: `src/components/about/` and `src/components/about/pages/`
+- SPA routes: `src/App.js`
+
+## Build / deploy notes that affect SEO
+- The app is an SPA served from `build/index.html`.
+- Netlify redirects all routes to `/index.html`, so raw HTML is otherwise identical for every route.
+- Google may see raw HTML canonical/meta before client-side React updates run.
+- Public marketing pages under `/about` need edge-injected canonical/title/meta tags for crawlable route-specific HTML.
+- Netlify edge functions are configured in `netlify.toml`.
+
+## Codebase conventions
+- New SEO landing pages are added to `SEO_PAGES` in `src/components/about/seoPageConfig.js`.
+- Add matching public sitemap entries in `netlify/edge-functions/sitemap.js`.
+- Add matching route metadata in `netlify/edge-functions/seo-head.js` so the raw HTML canonical matches the final SPA route.
+- Internal links between marketing pages use React Router `<Link to="/about/<slug>">`.
+- Do not add authenticated app, admin, teacher, portal, or login routes to the public sitemap.
+
+## Standing notes / do-not-touch
+- `/app/`, `/admin`, `/teacher`, and `/portal` are intentionally disallowed in robots.txt.
+- `/login` is a public app entry point but is not an SEO landing page and should stay out of the sitemap.
+
+## Prior SEO fixes
+- 2026-05-28 - GSC alternate canonical pages for `/about/*` SEO routes - PR TBD - files: `netlify/edge-functions/seo-head.js`, `netlify.toml`, `netlify/edge-functions/sitemap.js`, `AGENTS.md`, `CLAUDE.md` - notes: Added edge-injected route-specific canonical/title/meta for `/about` pages and removed `/login` from sitemap.
+
+## Open watch-items
+- GSC reported 10 "Alternate page with proper canonical tag" URLs for `/about/*`; validation started 2026-05-27 before this fix and should be monitored after deploy.
+- GSC reported "Crawled - currently not indexed" for `http://mathwhizapp.kids/` and `https://mathwhizapp.kids/about`; monitor after route-specific raw canonical tags deploy.
+- Core Web Vitals has no field data for mobile or desktop as of 2026-05-25.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@
 - `/login` is a public app entry point but is not an SEO landing page and should stay out of the sitemap.
 
 ## Prior SEO fixes
-- 2026-05-28 - GSC alternate canonical pages for `/about/*` SEO routes - PR TBD - files: `netlify/edge-functions/seo-head.js`, `netlify.toml`, `netlify/edge-functions/sitemap.js`, `AGENTS.md`, `CLAUDE.md` - notes: Added edge-injected route-specific canonical/title/meta for `/about` pages and removed `/login` from sitemap.
+- 2026-05-28 - GSC alternate canonical pages for `/about/*` SEO routes - PR https://github.com/BorisBesky/math-whiz-app/pull/51 - files: `netlify/edge-functions/seo-head.js`, `netlify.toml`, `netlify/edge-functions/sitemap.js`, `AGENTS.md`, `CLAUDE.md` - notes: Added edge-injected route-specific canonical/title/meta for `/about` pages and removed `/login` from sitemap.
 
 ## Open watch-items
 - GSC reported 10 "Alternate page with proper canonical tag" URLs for `/about/*`; validation started 2026-05-27 before this fix and should be monitored after deploy.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@
 - `/login` is not an SEO landing page and should not be submitted in the sitemap.
 
 ## Prior SEO fixes (most recent first)
-- 2026-05-28 - Alternate canonical pages for `/about/*` in GSC - PR TBD - files: `netlify/edge-functions/seo-head.js`, `netlify.toml`, `netlify/edge-functions/sitemap.js`, `AGENTS.md`, `CLAUDE.md` - notes: Added edge-injected route-specific canonical/title/meta for `/about` pages and removed `/login` from sitemap.
+- 2026-05-28 - Alternate canonical pages for `/about/*` in GSC - PR https://github.com/BorisBesky/math-whiz-app/pull/51 - files: `netlify/edge-functions/seo-head.js`, `netlify.toml`, `netlify/edge-functions/sitemap.js`, `AGENTS.md`, `CLAUDE.md` - notes: Added edge-injected route-specific canonical/title/meta for `/about` pages and removed `/login` from sitemap.
 
 ## Open watch-items
 - GSC reported 10 alternate-canonical `/about/*` pages and 2 crawled-not-indexed URLs (`http://mathwhizapp.kids/`, `https://mathwhizapp.kids/about`) on 2026-05-28.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,44 @@
-# Math Whiz App — Codebase Guide
+# CLAUDE.md - math-whiz-app
+
+## Site
+- URL: https://mathwhizapp.kids
+- Purpose: Free adaptive math practice app for 3rd and 4th grade students, teachers, and parents.
+
+## Tech stack
+- React 19 / Create React App SPA, React Router DOM 7, Tailwind CSS 3
+- Firebase Auth + Firestore
+- Netlify hosting, functions, and edge functions
+
+## SEO-relevant file map
+- Sitemap: `netlify/edge-functions/sitemap.js`
+- Robots.txt: `netlify/edge-functions/robots.js`
+- `<head>` / base meta template: `public/index.html`
+- Route-specific client meta: `src/components/about/SeoHead.js`, `src/components/about/AboutOverview.js`
+- Route-specific raw HTML meta: `netlify/edge-functions/seo-head.js`
+- Schema.org JSON-LD: emitted by `src/components/about/SeoHead.js`
+- Layout / page templates: `src/components/about/AboutLayout.js`, `src/components/about/AboutSeoPage.js`, `src/components/about/pages/*`
+
+## Codebase conventions
+- New SEO pages are registered in `src/components/about/seoPageConfig.js`.
+- Public SEO pages should also be added to `netlify/edge-functions/sitemap.js` and `netlify/edge-functions/seo-head.js`.
+- Authenticated app routes are intentionally excluded from robots and sitemap.
+- Internal SEO links use React Router `<Link>` with `/about/<slug>` paths.
+
+## Standing notes / do-not-touch
+- `/app/`, `/admin`, `/teacher`, and `/portal` are intentionally disallowed in robots.txt.
+- `/login` is not an SEO landing page and should not be submitted in the sitemap.
+
+## Prior SEO fixes (most recent first)
+- 2026-05-28 - Alternate canonical pages for `/about/*` in GSC - PR TBD - files: `netlify/edge-functions/seo-head.js`, `netlify.toml`, `netlify/edge-functions/sitemap.js`, `AGENTS.md`, `CLAUDE.md` - notes: Added edge-injected route-specific canonical/title/meta for `/about` pages and removed `/login` from sitemap.
+
+## Open watch-items
+- GSC reported 10 alternate-canonical `/about/*` pages and 2 crawled-not-indexed URLs (`http://mathwhizapp.kids/`, `https://mathwhizapp.kids/about`) on 2026-05-28.
+- Sitemap is successful and was last read 2026-05-27, with 16 discovered pages before `/login` was removed.
+- Core Web Vitals has insufficient field data for both mobile and desktop as of 2026-05-25.
+
+---
+
+# Math Whiz App - Codebase Guide
 
 ## Stack
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -22,6 +22,14 @@
   path = "/robots.txt"
   function = "robots"
 
+[[edge_functions]]
+  path = "/about"
+  function = "seo-head"
+
+[[edge_functions]]
+  path = "/about/*"
+  function = "seo-head"
+
 [[redirects]]
   from = "/admin"
   to = "/index.html"

--- a/netlify/edge-functions/seo-head.js
+++ b/netlify/edge-functions/seo-head.js
@@ -1,0 +1,154 @@
+const SITE_URL = "https://mathwhizapp.kids";
+
+const ABOUT_OVERVIEW = {
+  title: "Math Whiz - Adaptive Math Practice for 3rd & 4th Graders",
+  description:
+    "Free adaptive math practice for 3rd and 4th graders. Teachers create classes, track progress, and add custom content while students earn rewards.",
+};
+
+const SEO_PAGES = {
+  "best-math-app-3rd-grade": {
+    title: "Best Math App for 3rd Graders - Free & Adaptive | Math Whiz",
+    description:
+      "Looking for the best math app for 3rd graders? Math Whiz offers adaptive practice in multiplication, division, fractions, and geometry aligned to Common Core standards.",
+  },
+  "best-math-app-4th-grade": {
+    title: "Best Math App for 4th Graders - Free & Adaptive | Math Whiz",
+    description:
+      "Find the best math app for 4th graders. Math Whiz covers multi-digit multiplication, fractions, geometry, and measurement with adaptive difficulty and teacher dashboards.",
+  },
+  "math-practice-app-3rd-grade": {
+    title: "Math Practice App for 3rd Grade - Daily Practice That Works | Math Whiz",
+    description:
+      "Help your 3rd grader build math fluency with daily adaptive practice. Math Whiz covers multiplication, division, fractions, and more with progress tracking.",
+  },
+  "teacher-dashboard": {
+    title: "Math App with Teacher Dashboard - Class Management & Analytics | Math Whiz",
+    description:
+      "Manage your math classroom with real-time analytics, per-student assignments, custom content, and AI question generation. Free teacher dashboard included.",
+  },
+  "standards-aligned-math-app": {
+    title: "Standards-Aligned Math App for Elementary - Common Core | Math Whiz",
+    description:
+      "Every question in Math Whiz maps to Common Core standards for 3rd and 4th grade math. See exactly which standards your students are practicing.",
+  },
+  "multiplication-practice-3rd-grade": {
+    title: "Multiplication Practice App for 3rd Grade - Build Fluency | Math Whiz",
+    description:
+      "Help your 3rd grader master multiplication with adaptive practice, arrays, word problems, and visual tools. Free multiplication app aligned to Common Core.",
+  },
+  "fractions-app-for-kids": {
+    title: "Fractions App for Kids - Visual & Adaptive Practice | Math Whiz",
+    description:
+      "Make fractions click for your child. Math Whiz uses visual models, adaptive difficulty, and step-by-step explanations to build real fraction understanding.",
+  },
+  "fun-math-app-elementary": {
+    title: "Fun Math App for Elementary School - Rewards & Drawing | Math Whiz",
+    description:
+      "Math practice that kids actually enjoy. Earn coins, unlock rewards, draw your work, and level up with adaptive challenges. Free for elementary students.",
+  },
+  "free-math-practice-app": {
+    title: "Free Math Practice App for Elementary - No Ads, No Limits | Math Whiz",
+    description:
+      "Math Whiz is 100% free with no ads, no paywalls, and no limits. Full access to adaptive practice, teacher tools, and all topics for 3rd and 4th graders.",
+  },
+  "adaptive-math-app": {
+    title: "Adaptive Math App for Kids - Personalized Practice | Math Whiz",
+    description:
+      "Math Whiz adapts to your child's level in real time. Questions get harder as they improve and easier when they struggle.",
+  },
+  "common-core-math-app": {
+    title: "Common Core Math App for 3rd & 4th Grade | Math Whiz",
+    description:
+      "Every Math Whiz question maps to specific Common Core standards. See topic-by-standard breakdowns for 3rd and 4th grade math.",
+  },
+  "math-app-with-rewards": {
+    title: "Math App with Rewards for Kids - Coins & Store | Math Whiz",
+    description:
+      "Kids earn coins for correct answers and spend them in the store. Math Whiz uses rewards to keep students motivated without pay-to-win mechanics.",
+  },
+  "division-practice-3rd-grade": {
+    title: "Division Practice App for 3rd Grade - Master the Basics | Math Whiz",
+    description:
+      "Build division fluency for 3rd graders with adaptive practice, word problems, and visual tools. Connects division to multiplication for deeper understanding.",
+  },
+};
+
+function escapeAttribute(value) {
+  return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;");
+}
+
+function replaceTag(html, pattern, replacement) {
+  return pattern.test(html) ? html.replace(pattern, replacement) : html.replace("</head>", `${replacement}</head>`);
+}
+
+function pageData(pathname) {
+  if (pathname === "/about") {
+    return { ...ABOUT_OVERVIEW, canonical: `${SITE_URL}/about` };
+  }
+
+  const match = pathname.match(/^\/about\/([^/]+)\/?$/);
+  if (!match) return null;
+
+  const page = SEO_PAGES[match[1]];
+  if (!page) return null;
+
+  return { ...page, canonical: `${SITE_URL}/about/${match[1]}` };
+}
+
+export default async (request, context) => {
+  if (request.method !== "GET") return context.next();
+
+  const url = new URL(request.url);
+  const data = pageData(url.pathname);
+  if (!data) return context.next();
+
+  const response = await context.next();
+  const contentType = response.headers.get("content-type") || "";
+  if (!contentType.includes("text/html")) return response;
+
+  let html = await response.text();
+  const title = escapeAttribute(data.title);
+  const description = escapeAttribute(data.description);
+  const canonical = escapeAttribute(data.canonical);
+
+  html = replaceTag(html, /<title>.*?<\/title>/i, `<title>${title}</title>`);
+  html = replaceTag(
+    html,
+    /<meta\s+name="description"\s+content="[^"]*"\s*\/?>/i,
+    `<meta name="description" content="${description}" />`,
+  );
+  html = replaceTag(
+    html,
+    /<link\s+rel="canonical"\s+href="[^"]*"\s*\/?>/i,
+    `<link rel="canonical" href="${canonical}" />`,
+  );
+  html = replaceTag(
+    html,
+    /<meta\s+property="og:title"\s+content="[^"]*"\s*\/?>/i,
+    `<meta property="og:title" content="${title}" />`,
+  );
+  html = replaceTag(
+    html,
+    /<meta\s+property="og:description"\s+content="[^"]*"\s*\/?>/i,
+    `<meta property="og:description" content="${description}" />`,
+  );
+  html = replaceTag(
+    html,
+    /<meta\s+name="twitter:title"\s+content="[^"]*"\s*\/?>/i,
+    `<meta name="twitter:title" content="${title}" />`,
+  );
+  html = replaceTag(
+    html,
+    /<meta\s+name="twitter:description"\s+content="[^"]*"\s*\/?>/i,
+    `<meta name="twitter:description" content="${description}" />`,
+  );
+
+  const headers = new Headers(response.headers);
+  headers.set("cache-control", "public, max-age=0, must-revalidate");
+  return new Response(html, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+};

--- a/netlify/edge-functions/sitemap.js
+++ b/netlify/edge-functions/sitemap.js
@@ -14,7 +14,6 @@ const URLS = [
   { path: "/about/common-core-math-app", changefreq: "monthly", priority: "0.7" },
   { path: "/about/math-app-with-rewards", changefreq: "monthly", priority: "0.7" },
   { path: "/about/division-practice-3rd-grade", changefreq: "monthly", priority: "0.7" },
-  { path: "/login", changefreq: "monthly", priority: "0.7" },
 ];
 
 export default async (request) => {


### PR DESCRIPTION
## GSC issue addressed
- Property: https://mathwhizapp.kids
- Issue: 10 URLs reported as Alternate page with proper canonical tag for /about/* SEO pages.
- Related issue: 2 Crawled - currently not indexed samples: http://mathwhizapp.kids/ and https://mathwhizapp.kids/about.
- Diagnosis: live raw HTML for /about and /about/* still emitted canonical https://mathwhizapp.kids/ before the SPA updated head tags client-side.

## Diff summary
- Added a Netlify edge function that injects route-specific title, meta description, OG/Twitter metadata, and canonical tags for /about and /about/* before crawlers see the HTML.
- Registered the edge function in netlify.toml.
- Removed /login from the public sitemap because it is not an SEO landing page.
- Added root AGENTS.md and updated CLAUDE.md with SEO file map, conventions, prior-fix log, and watch-items.

## Validation
- node --check netlify/edge-functions/seo-head.js
- node --check netlify/edge-functions/sitemap.js
- npm run build

## Caveats / follow-up
- After deploy, request/monitor GSC validation for the alternate-canonical group.
- Core Web Vitals still has insufficient field data for both mobile and desktop.

Opened by the daily scheduled GSC technical SEO triage task.