### PR TITLE
Fix EditClassForm design pattern and add missing portal tests

### DIFF
--- a/src/__tests__/teacher-ai-focus-analysis.test.js
+++ b/src/__tests__/teacher-ai-focus-analysis.test.js
@@ -82,16 +82,25 @@ describe('teacher-ai-focus-analysis handler', () => {
     mockDocs = new Map();
     mockSets = [];
     mockVerifyIdToken = jest.fn().mockResolvedValue({ uid: 'teacher-1', role: 'teacher' });
-    const makeDocRef = (path) => ({
-      path,
-      get: jest.fn().mockResolvedValue(mockDocs.get(path) || docSnap(null)),
-      set: jest.fn().mockImplementation(async (data, options) => {
-        mockSets.push({ path, data, options });
-      }),
-      collection: (name) => ({
-        doc: (id) => makeDocRef(`${path}/${name}/${id}`),
-      }),
-    });
+    const makeDocRef = (path) => {
+      const makeCollRef = (collPath) => {
+        const q = {
+          doc: (id) => makeDocRef(`${collPath}/${id}`),
+          where: jest.fn(() => q),
+          orderBy: jest.fn(() => q),
+          get: jest.fn().mockResolvedValue({ docs: [] }),
+        };
+        return q;
+      };
+      return {
+        path,
+        get: jest.fn().mockResolvedValue(mockDocs.get(path) || docSnap(null)),
+        set: jest.fn().mockImplementation(async (data, options) => {
+          mockSets.push({ path, data, options });
+        }),
+        collection: (name) => makeCollRef(`${path}/${name}`),
+      };
+    };
     mockDoc = jest.fn((path) => makeDocRef(path));
     mockFetch = jest.fn().mockResolvedValue({ status: 202 });
     mockGenerateContentWithRetry = jest.fn().mockResolvedValue({

--- a/src/components/EditClassForm.js
+++ b/src/components/EditClassForm.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { X, BookOpen } from 'lucide-react';
+import ModalWrapper from './ui/ModalWrapper';
 
 const EditClassForm = ({ classData, onSubmit, onCancel }) => {
   const [formData, setFormData] = useState({
@@ -7,45 +7,31 @@ const EditClassForm = ({ classData, onSubmit, onCancel }) => {
     description: classData.description || '',
     gradeLevel: classData.gradeLevel || '',
     questionBankProbability: classData.questionBankProbability !== undefined ? classData.questionBankProbability : 0.7,
-    questionMasteryThreshold: classData.questionMasteryThreshold !== undefined ? classData.questionMasteryThreshold : 3
+    questionMasteryThreshold: classData.questionMasteryThreshold !== undefined ? classData.questionMasteryThreshold : 3,
   });
   const [loading, setLoading] = useState(false);
   const [errors, setErrors] = useState({});
 
-  const gradeLevels = [
-    'G3',
-    'G4'
-  ];
+  const gradeLevels = ['G3', 'G4'];
 
   const validateForm = () => {
     const newErrors = {};
-    
     if (!formData.name.trim()) {
       newErrors.name = 'Class name is required';
     }
-    
     if (!formData.gradeLevel.trim()) {
       newErrors.gradeLevel = 'Grade level is required';
     }
-
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
   };
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    
-    if (!validateForm()) {
-      return;
-    }
-
+    if (!validateForm()) return;
     setLoading(true);
-    
     try {
-      await onSubmit({
-        ...formData,
-        updatedAt: new Date()
-      });
+      await onSubmit({ ...formData, updatedAt: new Date() });
     } catch (error) {
       console.error('Error updating class:', error);
     } finally {
@@ -55,177 +41,150 @@ const EditClassForm = ({ classData, onSubmit, onCancel }) => {
 
   const handleChange = (e) => {
     const { name, value } = e.target;
-    setFormData(prev => ({
-      ...prev,
-      [name]: value
-    }));
-    
-    // Clear error when user starts typing
+    setFormData((prev) => ({ ...prev, [name]: value }));
     if (errors[name]) {
-      setErrors(prev => ({
-        ...prev,
-        [name]: ''
-      }));
+      setErrors((prev) => ({ ...prev, [name]: '' }));
     }
   };
 
   const handleProbabilityChange = (e) => {
-    const value = parseFloat(e.target.value);
-    setFormData(prev => ({
-      ...prev,
-      questionBankProbability: value
-    }));
+    setFormData((prev) => ({ ...prev, questionBankProbability: parseFloat(e.target.value) }));
   };
 
   const handleThresholdChange = (e) => {
     const value = Math.max(1, Math.min(20, parseInt(e.target.value, 10) || 1));
-    setFormData(prev => ({
-      ...prev,
-      questionMasteryThreshold: value
-    }));
+    setFormData((prev) => ({ ...prev, questionMasteryThreshold: value }));
   };
 
   return (
-    <div className="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50">
-      <div className="relative top-20 mx-auto p-5 border w-96 shadow-lg rounded-md bg-white">
-        <div className="mt-3">
-          <div className="flex items-center justify-between mb-4">
-            <div className="flex items-center space-x-2">
-              <BookOpen className="h-6 w-6 text-blue-600" />
-              <h3 className="text-lg font-medium text-gray-900">Edit Class</h3>
-            </div>
-            <button
-              onClick={onCancel}
-              className="text-gray-400 hover:text-gray-600"
-            >
-              <X className="h-6 w-6" />
-            </button>
+    <ModalWrapper isOpen={true} onClose={onCancel} title="Edit Class" size="sm">
+      <div className="p-6">
+        <p className="text-sm text-gray-600 mb-4">
+          Update the class details below.
+        </p>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label htmlFor="edit-name" className="block text-sm font-medium text-gray-700 mb-1">
+              Class Name *
+            </label>
+            <input
+              type="text"
+              id="edit-name"
+              name="name"
+              value={formData.name}
+              onChange={handleChange}
+              className={`w-full px-3 py-2 border rounded-button focus:outline-none focus:ring-2 focus:ring-brand-purple ${
+                errors.name ? 'border-red-300' : 'border-gray-300'
+              }`}
+              placeholder="e.g., Algebra 1 - Period 3"
+            />
+            {errors.name && <p className="mt-1 text-sm text-red-600">{errors.name}</p>}
           </div>
 
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <div>
-              <label htmlFor="name" className="block text-sm font-medium text-gray-700 mb-1">
-                Class Name *
-              </label>
+          <div>
+            <label htmlFor="edit-gradeLevel" className="block text-sm font-medium text-gray-700 mb-1">
+              Grade Level *
+            </label>
+            <select
+              id="edit-gradeLevel"
+              name="gradeLevel"
+              value={formData.gradeLevel}
+              onChange={handleChange}
+              className={`w-full px-3 py-2 border rounded-button focus:outline-none focus:ring-2 focus:ring-brand-purple ${
+                errors.gradeLevel ? 'border-red-300' : 'border-gray-300'
+              }`}
+            >
+              <option value="">Select grade level</option>
+              {gradeLevels.map((grade) => (
+                <option key={grade} value={grade}>{grade}</option>
+              ))}
+            </select>
+            {errors.gradeLevel && <p className="mt-1 text-sm text-red-600">{errors.gradeLevel}</p>}
+          </div>
+
+          <div>
+            <label htmlFor="edit-questionBankProbability" className="block text-sm font-medium text-gray-700 mb-1">
+              Question Bank Priority
+            </label>
+            <div className="flex items-center gap-3">
               <input
-                type="text"
-                id="name"
-                name="name"
-                value={formData.name}
-                onChange={handleChange}
-                className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 ${
-                  errors.name ? 'border-red-300' : 'border-gray-300'
-                }`}
-                placeholder="e.g., Algebra 1 - Period 3"
+                type="range"
+                id="edit-questionBankProbability"
+                min="0"
+                max="1"
+                step="0.1"
+                value={formData.questionBankProbability}
+                onChange={handleProbabilityChange}
+                className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
               />
-              {errors.name && <p className="mt-1 text-sm text-red-600">{errors.name}</p>}
+              <span className="font-semibold text-blue-600 bg-blue-100 px-3 py-1 rounded-full w-16 text-center text-sm">
+                {Math.round(formData.questionBankProbability * 100)}%
+              </span>
             </div>
+            <p className="mt-1 text-xs text-gray-500">
+              {formData.questionBankProbability === 0
+                ? 'Only generated questions (no uploaded questions)'
+                : formData.questionBankProbability === 1
+                ? 'Only uploaded questions (no generated questions)'
+                : `${Math.round(formData.questionBankProbability * 100)}% uploaded, ${Math.round((1 - formData.questionBankProbability) * 100)}% generated`}
+            </p>
+          </div>
 
-            <div>
-              <label htmlFor="gradeLevel" className="block text-sm font-medium text-gray-700 mb-1">
-                Grade Level *
-              </label>
-              <select
-                id="gradeLevel"
-                name="gradeLevel"
-                value={formData.gradeLevel}
-                onChange={handleChange}
-                className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 ${
-                  errors.gradeLevel ? 'border-red-300' : 'border-gray-300'
-                }`}
-              >
-                <option value="">Select grade level</option>
-                {gradeLevels.map(grade => (
-                  <option key={grade} value={grade}>{grade}</option>
-                ))}
-              </select>
-              {errors.gradeLevel && <p className="mt-1 text-sm text-red-600">{errors.gradeLevel}</p>}
-            </div>
-
-            <div>
-              <label htmlFor="questionBankProbability" className="block text-sm font-medium text-gray-700 mb-1">
-                Question Bank Priority
-              </label>
-              <div className="flex items-center gap-3">
-                <input
-                  type="range"
-                  id="questionBankProbability"
-                  min="0"
-                  max="1"
-                  step="0.1"
-                  value={formData.questionBankProbability}
-                  onChange={handleProbabilityChange}
-                  className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
-                />
-                <span className="font-semibold text-blue-600 bg-blue-100 px-3 py-1 rounded-full w-16 text-center text-sm">
-                  {Math.round(formData.questionBankProbability * 100)}%
-                </span>
-              </div>
-              <p className="mt-1 text-xs text-gray-500">
-                {formData.questionBankProbability === 0
-                  ? 'Only generated questions (no uploaded questions)'
-                  : formData.questionBankProbability === 1
-                  ? 'Only uploaded questions (no generated questions)'
-                  : `${Math.round(formData.questionBankProbability * 100)}% uploaded, ${Math.round((1 - formData.questionBankProbability) * 100)}% generated`}
-              </p>
-            </div>
-
-            <div>
-              <label htmlFor="questionMasteryThreshold" className="block text-sm font-medium text-gray-700 mb-1">
-                Question Mastery Threshold
-              </label>
-              <div className="flex items-center gap-3">
-                <input
-                  type="number"
-                  id="questionMasteryThreshold"
-                  min="1"
-                  max="20"
-                  value={formData.questionMasteryThreshold}
-                  onChange={handleThresholdChange}
-                  className="w-20 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-center"
-                />
-                <span className="text-sm text-gray-600">correct answers to retire a question type</span>
-              </div>
-              <p className="mt-1 text-xs text-gray-500">
-                After a student answers a tagged question type correctly this many times, it won't appear again.
-              </p>
-            </div>
-
-            <div>
-              <label htmlFor="description" className="block text-sm font-medium text-gray-700 mb-1">
-                Description
-              </label>
-              <textarea
-                id="description"
-                name="description"
-                rows={3}
-                value={formData.description}
-                onChange={handleChange}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-                placeholder="Brief description of the class..."
+          <div>
+            <label htmlFor="edit-questionMasteryThreshold" className="block text-sm font-medium text-gray-700 mb-1">
+              Question Mastery Threshold
+            </label>
+            <div className="flex items-center gap-3">
+              <input
+                type="number"
+                id="edit-questionMasteryThreshold"
+                min="1"
+                max="20"
+                value={formData.questionMasteryThreshold}
+                onChange={handleThresholdChange}
+                className="w-20 px-3 py-2 border border-gray-300 rounded-button focus:outline-none focus:ring-2 focus:ring-brand-purple text-center"
               />
+              <span className="text-sm text-gray-600">correct answers to retire a question type</span>
             </div>
+            <p className="mt-1 text-xs text-gray-500">
+              After a student answers a tagged question type correctly this many times, it won't appear again.
+            </p>
+          </div>
 
-            <div className="flex space-x-3 pt-4">
-              <button
-                type="button"
-                onClick={onCancel}
-                className="flex-1 px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 border border-gray-300 rounded-md hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-500"
-              >
-                Cancel
-              </button>
-              <button
-                type="submit"
-                disabled={loading}
-                className="flex-1 px-4 py-2 text-sm font-medium text-white bg-blue-600 border border-transparent rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {loading ? 'Updating...' : 'Update Class'}
-              </button>
-            </div>
-          </form>
-        </div>
+          <div>
+            <label htmlFor="edit-description" className="block text-sm font-medium text-gray-700 mb-1">
+              Description
+            </label>
+            <textarea
+              id="edit-description"
+              name="description"
+              rows={3}
+              value={formData.description}
+              onChange={handleChange}
+              className="w-full px-3 py-2 border border-gray-300 rounded-button focus:outline-none focus:ring-2 focus:ring-brand-purple"
+              placeholder="Brief description of the class..."
+            />
+          </div>
+
+          <div className="flex space-x-3 pt-4 border-t border-gray-200">
+            <button
+              type="button"
+              onClick={onCancel}
+              className="flex-1 px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-button hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-brand-purple"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={loading}
+              className="flex-1 px-4 py-2 text-sm font-medium text-white bg-brand-purple border border-transparent rounded-button hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-brand-purple disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {loading ? 'Updating...' : 'Update Class'}
+            </button>
+          </div>
+        </form>
       </div>
-    </div>
+    </ModalWrapper>
   );
 };
 

--- a/src/components/__tests__/EditClassForm.test.js
+++ b/src/components/__tests__/EditClassForm.test.js
@@ -1,0 +1,121 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+jest.mock('../ui/ModalWrapper', () => {
+  const React = require('react');
+  return function MockModalWrapper({ isOpen, onClose, title, children }) {
+    if (!isOpen) return null;
+    return React.createElement(
+      'div',
+      { 'data-testid': 'modal-wrapper', 'data-title': title },
+      children
+    );
+  };
+});
+
+const EditClassForm = require('../EditClassForm').default;
+
+const defaultClass = {
+  name: 'Room 5',
+  description: 'Morning group',
+  gradeLevel: 'G3',
+  questionBankProbability: 0.7,
+  questionMasteryThreshold: 3,
+};
+
+const renderForm = (overrides = {}) => {
+  const props = {
+    classData: defaultClass,
+    onSubmit: jest.fn().mockResolvedValue(undefined),
+    onCancel: jest.fn(),
+    ...overrides,
+  };
+  return { ...render(<EditClassForm {...props} />), props };
+};
+
+describe('EditClassForm', () => {
+  it('renders inside ModalWrapper', () => {
+    renderForm();
+    expect(screen.getByTestId('modal-wrapper')).toBeInTheDocument();
+  });
+
+  it('pre-populates the name field with classData', () => {
+    renderForm();
+    expect(screen.getByDisplayValue('Room 5')).toBeInTheDocument();
+  });
+
+  it('pre-populates the grade level with classData', () => {
+    renderForm();
+    expect(screen.getByDisplayValue('G3')).toBeInTheDocument();
+  });
+
+  it('shows a validation error when name is cleared and submitted', async () => {
+    renderForm();
+    fireEvent.change(screen.getByLabelText(/class name/i), { target: { value: '' } });
+    fireEvent.submit(screen.getByRole('button', { name: /update class/i }).closest('form'));
+    expect(await screen.findByText('Class name is required')).toBeInTheDocument();
+  });
+
+  it('shows a validation error when grade level is cleared and submitted', async () => {
+    renderForm();
+    fireEvent.change(screen.getByLabelText(/grade level/i), { target: { value: '' } });
+    fireEvent.submit(screen.getByRole('button', { name: /update class/i }).closest('form'));
+    expect(await screen.findByText('Grade level is required')).toBeInTheDocument();
+  });
+
+  it('clears the name validation error when the user types', async () => {
+    renderForm();
+    fireEvent.change(screen.getByLabelText(/class name/i), { target: { value: '' } });
+    fireEvent.submit(screen.getByRole('button', { name: /update class/i }).closest('form'));
+    expect(await screen.findByText('Class name is required')).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText(/class name/i), { target: { value: 'New Name' } });
+    expect(screen.queryByText('Class name is required')).not.toBeInTheDocument();
+  });
+
+  it('calls onSubmit with the updated form data on valid submission', async () => {
+    const onSubmit = jest.fn().mockResolvedValue(undefined);
+    renderForm({ onSubmit });
+    fireEvent.change(screen.getByLabelText(/class name/i), { target: { value: 'Updated Name' } });
+    fireEvent.submit(screen.getByRole('button', { name: /update class/i }).closest('form'));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Updated Name', gradeLevel: 'G3' })
+    ));
+  });
+
+  it('includes updatedAt in the submitted data', async () => {
+    const onSubmit = jest.fn().mockResolvedValue(undefined);
+    renderForm({ onSubmit });
+    fireEvent.submit(screen.getByRole('button', { name: /update class/i }).closest('form'));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ updatedAt: expect.any(Date) })
+    ));
+  });
+
+  it('disables the submit button while loading', async () => {
+    let resolveSubmit;
+    const onSubmit = jest.fn(() => new Promise((res) => { resolveSubmit = res; }));
+    renderForm({ onSubmit });
+    fireEvent.submit(screen.getByRole('button', { name: /update class/i }).closest('form'));
+    expect(screen.getByRole('button', { name: /updating/i })).toBeDisabled();
+    resolveSubmit();
+    await waitFor(() => expect(screen.getByRole('button', { name: /update class/i })).not.toBeDisabled());
+  });
+
+  it('calls onCancel when the Cancel button is clicked', () => {
+    const onCancel = jest.fn();
+    renderForm({ onCancel });
+    fireEvent.click(screen.getByRole('button', { name: /^cancel$/i }));
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('renders G3 and G4 as grade level options', () => {
+    renderForm();
+    expect(screen.getByRole('option', { name: 'G3' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'G4' })).toBeInTheDocument();
+  });
+
+  it('reflects the mastery threshold from classData', () => {
+    renderForm({ classData: { ...defaultClass, questionMasteryThreshold: 5 } });
+    expect(screen.getByDisplayValue('5')).toBeInTheDocument();
+  });
+});

--- a/src/components/portal/__tests__/StudentsSection.test.js
+++ b/src/components/portal/__tests__/StudentsSection.test.js
@@ -409,4 +409,52 @@ describe('StudentsSection - Focus integration', () => {
   });
 });
 
+describe('StudentsSection - multi-class enrollment display', () => {
+  beforeEach(() => {
+    mockGetDoc.mockResolvedValue({ exists: () => false, data: () => ({}) });
+    mockGetIdToken.mockResolvedValue('token-abc');
+    getAuth.mockReturnValue({
+      currentUser: { getIdToken: (...args) => mockGetIdToken(...args) },
+    });
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, json: async () => ({ status: 'ok', mode: 'get', savedRecommendation: null }) })
+    );
+  });
+
+  afterEach(() => {
+    delete global.fetch;
+  });
+
+  it('shows className for a student enrolled in multiple classes', () => {
+    const multiClassStudent = {
+      ...baseStudent,
+      className: 'Room 101, Room 202',
+      classIds: ['class-1', 'class-2'],
+    };
+    renderSection([multiClassStudent]);
+    expect(screen.getByText('Room 101, Room 202')).toBeInTheDocument();
+  });
+
+  it('displays Unassigned when student has no class', () => {
+    const unassignedStudent = {
+      ...baseStudent,
+      className: 'Unassigned',
+      classId: null,
+      classIds: [],
+    };
+    renderSection([unassignedStudent]);
+    expect(screen.getByText('Unassigned')).toBeInTheDocument();
+  });
+
+  it('passes all classIds to StudentFocusModal when opened', () => {
+    const multiClassStudent = {
+      ...baseStudent,
+      classIds: ['class-1', 'class-2'],
+    };
+    renderSection([multiClassStudent]);
+    fireEvent.click(screen.getByRole('button', { name: /set focus subtopics/i }));
+    expect(screen.getByTestId('student-focus-modal')).toBeInTheDocument();
+  });
+});
+
 export {};

--- a/src/components/portal/sections/__tests__/ClassDetailPanel.test.js
+++ b/src/components/portal/sections/__tests__/ClassDetailPanel.test.js
@@ -74,6 +74,22 @@ jest.mock('../../../messaging/MessageComposer', () => {
   };
 });
 
+jest.mock('../../../EditClassForm', () => {
+  const React = require('react');
+  return {
+    __esModule: true,
+    default: function MockEditClassForm({ classData, onSubmit, onCancel }) {
+      return React.createElement(
+        'div',
+        { 'data-testid': 'edit-class-form' },
+        React.createElement('span', null, `Editing: ${classData?.name}`),
+        React.createElement('button', { onClick: () => onSubmit({ name: 'Updated', gradeLevel: 'G4' }) }, 'Save Edit'),
+        React.createElement('button', { onClick: onCancel }, 'Cancel Edit'),
+      );
+    },
+  };
+});
+
 const ClassDetailPanel = require('../ClassDetailPanel').default;
 
 const makeClass = (overrides = {}) => ({
@@ -260,5 +276,90 @@ describe('ClassDetailPanel', () => {
     // Each teacher gets a Remove button (admin, multiple teachers)
     const teacherRemoveButtons = screen.getAllByRole('button', { name: /^remove$/i });
     expect(teacherRemoveButtons.length).toBeGreaterThanOrEqual(2);
+  });
+
+  describe('Edit Class feature', () => {
+    const editProps = {
+      ...defaultProps,
+      onEditClass: jest.fn().mockResolvedValue(undefined),
+      showEditForm: false,
+      setShowEditForm: jest.fn(),
+    };
+
+    it('shows Edit Class button when onEditClass and setShowEditForm are provided and user is on the class', () => {
+      render(<ClassDetailPanel {...editProps} />);
+      expect(screen.getByRole('button', { name: /edit class/i })).toBeInTheDocument();
+    });
+
+    it('does not show Edit Class button when onEditClass is not provided', () => {
+      render(<ClassDetailPanel {...defaultProps} />);
+      expect(screen.queryByRole('button', { name: /edit class/i })).not.toBeInTheDocument();
+    });
+
+    it('does not show Edit Class button when user is not on the class', () => {
+      render(<ClassDetailPanel {...editProps} userId="other-teacher" />);
+      expect(screen.queryByRole('button', { name: /edit class/i })).not.toBeInTheDocument();
+    });
+
+    it('calls setShowEditForm(true) when Edit Class is clicked', () => {
+      const setShowEditForm = jest.fn();
+      render(<ClassDetailPanel {...editProps} setShowEditForm={setShowEditForm} />);
+      fireEvent.click(screen.getByRole('button', { name: /edit class/i }));
+      expect(setShowEditForm).toHaveBeenCalledWith(true);
+    });
+
+    it('renders EditClassForm when showEditForm is true', () => {
+      render(<ClassDetailPanel {...editProps} showEditForm={true} />);
+      expect(screen.getByTestId('edit-class-form')).toBeInTheDocument();
+      expect(screen.getByText(`Editing: ${defaultProps.classItem.name}`)).toBeInTheDocument();
+    });
+
+    it('does not render EditClassForm when showEditForm is false', () => {
+      render(<ClassDetailPanel {...editProps} showEditForm={false} />);
+      expect(screen.queryByTestId('edit-class-form')).not.toBeInTheDocument();
+    });
+
+    it('calls onEditClass with submitted data when save is clicked', async () => {
+      const onEditClass = jest.fn().mockResolvedValue(undefined);
+      render(<ClassDetailPanel {...editProps} onEditClass={onEditClass} showEditForm={true} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Save Edit' }));
+      await waitFor(() => expect(onEditClass).toHaveBeenCalledWith({ name: 'Updated', gradeLevel: 'G4' }));
+    });
+
+    it('calls setShowEditForm(false) when Cancel Edit is clicked', () => {
+      const setShowEditForm = jest.fn();
+      render(<ClassDetailPanel {...editProps} setShowEditForm={setShowEditForm} showEditForm={true} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel Edit' }));
+      expect(setShowEditForm).toHaveBeenCalledWith(false);
+    });
+  });
+
+  describe('multi-class enrollment roster', () => {
+    it('includes students whose classIds array contains the classId', () => {
+      const multiClassStudent = makeStudent({
+        id: 'student-multi',
+        name: 'Multi',
+        classId: 'class-other',
+        classIds: ['class-1', 'class-other'],
+      });
+      render(
+        <ClassDetailPanel
+          {...defaultProps}
+          students={[makeStudent(), multiClassStudent]}
+        />
+      );
+      expect(screen.getByText('Multi')).toBeInTheDocument();
+    });
+
+    it('excludes students who are not enrolled in this class', () => {
+      const otherStudent = makeStudent({ id: 'student-other', name: 'Other', classId: 'class-9', classIds: ['class-9'] });
+      render(
+        <ClassDetailPanel
+          {...defaultProps}
+          students={[makeStudent(), otherStudent]}
+        />
+      );
+      expect(screen.queryByText('Other')).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/components/portal/sections/__tests__/ClassesSection.test.js
+++ b/src/components/portal/sections/__tests__/ClassesSection.test.js
@@ -1,0 +1,209 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+jest.mock('../../../../hooks/useConfirmation', () => ({
+  __esModule: true,
+  default: () => ({ confirmationProps: {}, confirm: jest.fn().mockResolvedValue(true) }),
+}));
+
+jest.mock('../../../ui/ConfirmationModal', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+// Prevent ClassDetailPanel from opening a full panel in these tests
+jest.mock('../ClassDetailPanel', () => {
+  const React = require('react');
+  return {
+    __esModule: true,
+    default: function MockClassDetailPanel({ classItem, onClose, onEditClass, showEditForm, setShowEditForm }) {
+      return React.createElement(
+        'div',
+        { 'data-testid': 'class-detail-panel' },
+        React.createElement('span', null, classItem?.name),
+        React.createElement('button', { onClick: onClose }, 'Close'),
+        typeof onEditClass === 'function' &&
+          React.createElement(
+            'button',
+            { onClick: () => setShowEditForm(true) },
+            'Open Edit Form'
+          ),
+        showEditForm &&
+          React.createElement(
+            'button',
+            {
+              onClick: async () => {
+                try {
+                  await onEditClass({ name: 'Updated', gradeLevel: 'G4' });
+                } catch (_) {
+                  // allow ClassesSection to display actionError via setActionError
+                }
+              },
+            },
+            'Submit Edit'
+          ),
+      );
+    },
+  };
+});
+
+jest.mock('../../../CreateClassForm', () => {
+  const React = require('react');
+  return {
+    __esModule: true,
+    default: function MockCreateClassForm({ onSubmit, onCancel }) {
+      return React.createElement(
+        'div',
+        { 'data-testid': 'create-class-form' },
+        React.createElement('button', { onClick: () => onSubmit({ name: 'New Class', gradeLevel: 'G3' }) }, 'Create'),
+        React.createElement('button', { onClick: onCancel }, 'Cancel'),
+      );
+    },
+  };
+});
+
+const ClassesSection = require('../ClassesSection').default;
+
+const makeClass = (overrides = {}) => ({
+  id: 'class-1',
+  name: 'Room 12',
+  subject: 'Math',
+  gradeLevel: 'G3',
+  teacherIds: ['teacher-1'],
+  teacherEmail: 'baker@school.com',
+  ...overrides,
+});
+
+const defaultProps = {
+  classes: [makeClass()],
+  classCounts: { 'class-1': 3 },
+  loading: false,
+  error: null,
+  userRole: 'teacher',
+  userId: 'teacher-1',
+  teachers: [{ uid: 'teacher-1', displayName: 'Ms. Baker', email: 'baker@school.com' }],
+  onCreateClass: jest.fn().mockResolvedValue(undefined),
+  onUpdateClass: jest.fn().mockResolvedValue(undefined),
+  onDeleteClass: jest.fn().mockResolvedValue(undefined),
+  students: [],
+  onAssignStudent: jest.fn(),
+  onRemoveStudent: jest.fn(),
+  onRefreshStudents: jest.fn(),
+};
+
+describe('ClassesSection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders a class card with name and student count', () => {
+    render(<ClassesSection {...defaultProps} />);
+    expect(screen.getByText('Room 12')).toBeInTheDocument();
+    expect(screen.getByText(/3 students/i)).toBeInTheDocument();
+  });
+
+  it('shows the loading spinner when loading is true', () => {
+    render(<ClassesSection {...defaultProps} loading={true} classes={[]} />);
+    expect(screen.getByText(/loading classes/i)).toBeInTheDocument();
+  });
+
+  it('shows the empty state message for a teacher with no classes', () => {
+    render(<ClassesSection {...defaultProps} classes={[]} />);
+    expect(screen.getByText(/no classes yet/i)).toBeInTheDocument();
+  });
+
+  it('shows the New Class button for teachers', () => {
+    render(<ClassesSection {...defaultProps} />);
+    expect(screen.getByRole('button', { name: /new class/i })).toBeInTheDocument();
+  });
+
+  it('does not show the New Class button when onCreateClass is not provided', () => {
+    render(<ClassesSection {...defaultProps} onCreateClass={undefined} />);
+    expect(screen.queryByRole('button', { name: /new class/i })).not.toBeInTheDocument();
+  });
+
+  it('renders the error message when error prop is set', () => {
+    render(<ClassesSection {...defaultProps} error="Failed to load" />);
+    expect(screen.getByText('Failed to load')).toBeInTheDocument();
+  });
+
+  it('opens the create class form when New Class is clicked', () => {
+    render(<ClassesSection {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /new class/i }));
+    expect(screen.getByTestId('create-class-form')).toBeInTheDocument();
+  });
+
+  it('closes the create class form after successful submission', async () => {
+    render(<ClassesSection {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /new class/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+    await waitFor(() => expect(screen.queryByTestId('create-class-form')).not.toBeInTheDocument());
+  });
+
+  it('hides the create form when Cancel is clicked', () => {
+    render(<ClassesSection {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /new class/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(screen.queryByTestId('create-class-form')).not.toBeInTheDocument();
+  });
+
+  it('opens the ClassDetailPanel when "View details" is clicked', () => {
+    render(<ClassesSection {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /view details/i }));
+    expect(screen.getByTestId('class-detail-panel')).toBeInTheDocument();
+    expect(screen.getAllByText('Room 12').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('closes the ClassDetailPanel when onClose is called', () => {
+    render(<ClassesSection {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /view details/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    expect(screen.queryByTestId('class-detail-panel')).not.toBeInTheDocument();
+  });
+
+  it('passes onEditClass handler to ClassDetailPanel when onUpdateClass is provided', () => {
+    render(<ClassesSection {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /view details/i }));
+    expect(screen.getByRole('button', { name: 'Open Edit Form' })).toBeInTheDocument();
+  });
+
+  it('does not pass onEditClass when onUpdateClass is not provided', () => {
+    render(<ClassesSection {...defaultProps} onUpdateClass={undefined} />);
+    fireEvent.click(screen.getByRole('button', { name: /view details/i }));
+    expect(screen.queryByRole('button', { name: 'Open Edit Form' })).not.toBeInTheDocument();
+  });
+
+  it('calls onUpdateClass when edit is submitted from the detail panel', async () => {
+    const onUpdateClass = jest.fn().mockResolvedValue(undefined);
+    render(<ClassesSection {...defaultProps} onUpdateClass={onUpdateClass} />);
+    fireEvent.click(screen.getByRole('button', { name: /view details/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Open Edit Form' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Submit Edit' }));
+    await waitFor(() => expect(onUpdateClass).toHaveBeenCalledWith('class-1', { name: 'Updated', gradeLevel: 'G4' }));
+  });
+
+  it('shows an action error when onUpdateClass throws', async () => {
+    const onUpdateClass = jest.fn().mockRejectedValue(new Error('Update failed'));
+    render(<ClassesSection {...defaultProps} onUpdateClass={onUpdateClass} />);
+    fireEvent.click(screen.getByRole('button', { name: /view details/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Open Edit Form' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Submit Edit' }));
+    expect(await screen.findByText('Update failed')).toBeInTheDocument();
+  });
+
+  it('sorts class cards alphabetically by name', () => {
+    const classes = [
+      makeClass({ id: 'b', name: 'Zoo Class' }),
+      makeClass({ id: 'a', name: 'Alpha Class' }),
+    ];
+    render(<ClassesSection {...defaultProps} classes={classes} classCounts={{}} />);
+    const names = screen.getAllByRole('heading', { level: 4 }).map((el) => el.textContent);
+    expect(names[0]).toBe('Alpha Class');
+    expect(names[1]).toBe('Zoo Class');
+  });
+
+  it('shows admin teacher email column for admin role', () => {
+    render(<ClassesSection {...defaultProps} userRole="admin" />);
+    expect(screen.getByText(/baker@school\.com/i)).toBeInTheDocument();
+  });
+});

--- a/src/hooks/__tests__/useClassAssignments.test.js
+++ b/src/hooks/__tests__/useClassAssignments.test.js
@@ -1,0 +1,147 @@
+let mockGetIdToken;
+let mockUpdateDoc;
+let mockGetDocs;
+let mockDoc;
+
+jest.mock('firebase/auth', () => ({
+  getAuth: jest.fn(),
+}));
+
+jest.mock('firebase/firestore', () => ({
+  getFirestore: jest.fn(() => ({})),
+  doc: (...args) => mockDoc(...args),
+  collection: jest.fn(() => 'collection-ref'),
+  query: jest.fn((ref) => ref),
+  where: jest.fn(() => 'where-clause'),
+  getDocs: (...args) => mockGetDocs(...args),
+  updateDoc: (...args) => mockUpdateDoc(...args),
+}));
+
+const { renderHook } = require('@testing-library/react');
+const useClassAssignments = require('../useClassAssignments').default;
+const { getAuth } = require('firebase/auth');
+
+describe('useClassAssignments', () => {
+  beforeEach(() => {
+    mockGetIdToken = jest.fn().mockResolvedValue('token-abc');
+    mockUpdateDoc = jest.fn().mockResolvedValue(undefined);
+    mockGetDocs = jest.fn();
+    mockDoc = jest.fn((...parts) => ({ path: parts.join('/') }));
+    getAuth.mockReturnValue({ currentUser: { getIdToken: mockGetIdToken } });
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    delete global.fetch;
+  });
+
+  describe('removeStudentFromClass', () => {
+    it('throws when studentId or classId is missing', async () => {
+      const { result } = renderHook(() => useClassAssignments({ appId: 'app-1' }));
+      await expect(
+        result.current.removeStudentFromClass({ studentId: '', classId: 'c1' })
+      ).rejects.toThrow('Student ID and class ID are required');
+    });
+
+    it('deletes the enrollment record and updates the student profile', async () => {
+      global.fetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => [{ id: 'enroll-1', studentId: 'student-1', classId: 'class-1' }],
+        })
+        .mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+
+      mockGetDocs.mockResolvedValueOnce({
+        empty: true,
+        docs: [],
+        forEach: () => {},
+      });
+
+      const { result } = renderHook(() => useClassAssignments({ appId: 'app-1' }));
+      await result.current.removeStudentFromClass({ studentId: 'student-1', classId: 'class-1' });
+
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      expect(mockUpdateDoc).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ classId: null })
+      );
+    });
+
+    it('sets the next primary classId when other enrollments remain', async () => {
+      global.fetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => [{ id: 'enroll-1', studentId: 'student-1', classId: 'class-1' }],
+        })
+        .mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+
+      mockGetDocs.mockResolvedValueOnce({
+        empty: false,
+        docs: [{ data: () => ({ classId: 'class-2' }) }],
+        forEach: () => {},
+      });
+
+      const { result } = renderHook(() => useClassAssignments({ appId: 'app-1' }));
+      await result.current.removeStudentFromClass({ studentId: 'student-1', classId: 'class-1' });
+
+      expect(mockUpdateDoc).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ classId: 'class-2' })
+      );
+    });
+
+    it('throws when enrollment lookup fails', async () => {
+      global.fetch.mockResolvedValueOnce({ ok: false, json: async () => ({ error: 'Not found' }) });
+      const { result } = renderHook(() => useClassAssignments({ appId: 'app-1' }));
+      await expect(
+        result.current.removeStudentFromClass({ studentId: 'student-1', classId: 'class-1' })
+      ).rejects.toThrow('Not found');
+    });
+
+    it('throws when user is not authenticated', async () => {
+      getAuth.mockReturnValueOnce({ currentUser: null });
+      const { result } = renderHook(() => useClassAssignments({ appId: 'app-1' }));
+      await expect(
+        result.current.removeStudentFromClass({ studentId: 'student-1', classId: 'class-1' })
+      ).rejects.toThrow('User not authenticated');
+    });
+  });
+
+  describe('assignStudentToClass', () => {
+    it('throws when studentId or classId is missing', async () => {
+      const { result } = renderHook(() => useClassAssignments({ appId: 'app-1' }));
+      await expect(
+        result.current.assignStudentToClass({ studentId: '', classId: '' })
+      ).rejects.toThrow('Student ID and class ID are required');
+    });
+
+    it('posts enrollment and updates the student profile classId', async () => {
+      global.fetch.mockResolvedValueOnce({ ok: true, json: async () => ({ id: 'enroll-new' }) });
+
+      const { result } = renderHook(() => useClassAssignments({ appId: 'app-1' }));
+      await result.current.assignStudentToClass({
+        studentId: 'student-2',
+        classId: 'class-3',
+        studentName: 'Bob',
+        studentEmail: 'bob@school.com',
+      });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/.netlify/functions/class-students',
+        expect.objectContaining({ method: 'POST' })
+      );
+      expect(mockUpdateDoc).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ classId: 'class-3' })
+      );
+    });
+
+    it('throws when the POST request fails', async () => {
+      global.fetch.mockResolvedValueOnce({ ok: false, json: async () => ({ error: 'Duplicate' }) });
+      const { result } = renderHook(() => useClassAssignments({ appId: 'app-1' }));
+      await expect(
+        result.current.assignStudentToClass({ studentId: 's1', classId: 'c1' })
+      ).rejects.toThrow('Duplicate');
+    });
+  });
+});

--- a/src/hooks/__tests__/usePortalClasses.test.js
+++ b/src/hooks/__tests__/usePortalClasses.test.js
@@ -1,0 +1,100 @@
+let mockGetIdToken;
+
+jest.mock('firebase/auth', () => ({
+  getAuth: jest.fn(),
+}));
+
+jest.mock('firebase/firestore', () => ({
+  getFirestore: jest.fn(() => ({})),
+  collection: jest.fn(() => 'collection-ref'),
+  addDoc: jest.fn(() => Promise.resolve({ id: 'new-class-id' })),
+  query: jest.fn((ref) => ref),
+  where: jest.fn(),
+  onSnapshot: jest.fn((ref, success) => {
+    success({ docs: [] });
+    return jest.fn();
+  }),
+}));
+
+const { renderHook, act } = require('@testing-library/react');
+const usePortalClasses = require('../usePortalClasses').default;
+const { getAuth } = require('firebase/auth');
+
+describe('usePortalClasses - updateClass', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetIdToken = jest.fn().mockResolvedValue('token-abc');
+    getAuth.mockReturnValue({ currentUser: { getIdToken: mockGetIdToken } });
+    global.fetch = jest.fn();
+    // Re-hook onSnapshot to call success callback
+    const { onSnapshot } = require('firebase/firestore');
+    onSnapshot.mockImplementation((ref, success) => { success({ docs: [] }); return jest.fn(); });
+  });
+
+  afterEach(() => {
+    delete global.fetch;
+  });
+
+  const renderHookWithRole = (role = 'teacher') =>
+    renderHook(() =>
+      usePortalClasses({ appId: 'test-app', userRole: role, userId: 'uid-1', userEmail: 'teacher@test.com' })
+    );
+
+  it('throws when classId is missing', async () => {
+    const { result } = renderHookWithRole();
+    await expect(result.current.updateClass('', { name: 'New' })).rejects.toThrow('Class ID is required');
+  });
+
+  it('throws when user role is not authorized', async () => {
+    const { result } = renderHookWithRole('student');
+    await expect(result.current.updateClass('class-1', { name: 'New' })).rejects.toThrow(
+      'You do not have permission to update classes'
+    );
+  });
+
+  it('throws when there is no authenticated user', async () => {
+    getAuth.mockReturnValueOnce({ currentUser: null });
+    const { result } = renderHookWithRole('teacher');
+    await expect(result.current.updateClass('class-1', { name: 'New' })).rejects.toThrow(
+      'Authentication required'
+    );
+  });
+
+  it('sends a PUT request with auth token and class data', async () => {
+    global.fetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+    const { result } = renderHookWithRole('teacher');
+    await act(async () => {
+      await result.current.updateClass('class-1', { name: 'Updated Room', gradeLevel: 'G4' });
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/.netlify/functions/classes?id=class-1',
+      expect.objectContaining({
+        method: 'PUT',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer token-abc',
+          'Content-Type': 'application/json',
+        }),
+        body: JSON.stringify({ name: 'Updated Room', gradeLevel: 'G4' }),
+      })
+    );
+  });
+
+  it('throws with the server error message when PUT fails', async () => {
+    global.fetch.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: 'Class not found' }),
+    });
+    const { result } = renderHookWithRole('admin');
+    await expect(result.current.updateClass('class-1', {})).rejects.toThrow('Class not found');
+  });
+
+  it('also allows admin role to update', async () => {
+    global.fetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+    const { result } = renderHookWithRole('admin');
+    await act(async () => {
+      await result.current.updateClass('class-1', { name: 'Admin Updated' });
+    });
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/services/__tests__/studentHistoryService.test.js
+++ b/src/services/__tests__/studentHistoryService.test.js
@@ -1,0 +1,97 @@
+let mockGetIdToken;
+
+jest.mock('firebase/auth', () => ({
+  getAuth: jest.fn(),
+}));
+
+const { fetchStudentHistory } = require('../studentHistoryService');
+const { getAuth } = require('firebase/auth');
+
+const okResponse = (body) =>
+  Promise.resolve({ ok: true, json: async () => body });
+
+const errResponse = (status, body) =>
+  Promise.resolve({ ok: false, status, json: async () => body });
+
+describe('fetchStudentHistory', () => {
+  beforeEach(() => {
+    mockGetIdToken = jest.fn().mockResolvedValue('token-test');
+    getAuth.mockReturnValue({ currentUser: { getIdToken: mockGetIdToken } });
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    delete global.fetch;
+  });
+
+  it('throws when no authenticated user', async () => {
+    getAuth.mockReturnValueOnce({ currentUser: null });
+    await expect(
+      fetchStudentHistory({ studentId: 'student-1' })
+    ).rejects.toThrow('No authenticated user found');
+  });
+
+  it('throws when studentId is missing', async () => {
+    await expect(fetchStudentHistory({})).rejects.toThrow('studentId is required');
+  });
+
+  it('sends a POST to get-student-history with correct payload', async () => {
+    global.fetch.mockResolvedValue(okResponse({ answeredQuestions: [] }));
+    await fetchStudentHistory({
+      appId: 'app-1',
+      studentId: 'student-1',
+      classId: 'class-1',
+      startDate: '2026-01-01',
+      endDate: '2026-01-07',
+    });
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/.netlify/functions/get-student-history',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer token-test',
+          'Content-Type': 'application/json',
+        }),
+        body: JSON.stringify({
+          appId: 'app-1',
+          studentId: 'student-1',
+          classId: 'class-1',
+          startDate: '2026-01-01',
+          endDate: '2026-01-07',
+        }),
+      })
+    );
+  });
+
+  it('returns the answeredQuestions array on success', async () => {
+    const questions = [{ id: 'q1', isCorrect: true }];
+    global.fetch.mockResolvedValue(okResponse({ answeredQuestions: questions }));
+    const result = await fetchStudentHistory({ studentId: 's1' });
+    expect(result).toEqual(questions);
+  });
+
+  it('returns an empty array when answeredQuestions is missing', async () => {
+    global.fetch.mockResolvedValue(okResponse({}));
+    const result = await fetchStudentHistory({ studentId: 's1' });
+    expect(result).toEqual([]);
+  });
+
+  it('throws with server error message on non-ok response', async () => {
+    global.fetch.mockResolvedValue(errResponse(500, { error: 'Server error' }));
+    await expect(fetchStudentHistory({ studentId: 's1' })).rejects.toThrow('Server error');
+  });
+
+  it('throws a generic status message when error body is empty', async () => {
+    global.fetch.mockResolvedValue(
+      Promise.resolve({ ok: false, status: 503, json: async () => { throw new Error('bad json'); } })
+    );
+    await expect(fetchStudentHistory({ studentId: 's1' })).rejects.toThrow('Request failed with status 503');
+  });
+
+  it('uses default appId when not provided', async () => {
+    global.fetch.mockResolvedValue(okResponse({ answeredQuestions: [] }));
+    await fetchStudentHistory({ studentId: 's1' });
+    const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+    expect(body.appId).toBe('default-app-id');
+  });
+});


### PR DESCRIPTION
EditClassForm was using its own backdrop overlay instead of the shared ModalWrapper, and used rounded-md/ring-blue-500 instead of the rounded-button/ring-brand-purple tokens from the portal design system. Migrated it to ModalWrapper to match CreateClassForm and all other portal modals.

Also fixes 5 pre-existing test failures in teacher-ai-focus-analysis where the Firestore collection mock lacked where/orderBy/get support after getStudentAttemptHistory was introduced in a recent commit.

New tests added for features introduced in the past week:
- EditClassForm.test.js (12 cases): rendering, validation, submit, cancel
- ClassesSection.test.js (17 cases): card display, CRUD actions, edit flow, sorting, role-based visibility
- ClassDetailPanel edit feature: 8 new cases for Edit Class button, EditClassForm integration, multi-class enrollment roster
- StudentsSection multi-class: 3 new cases for classIds display
- usePortalClasses.test.js (6 cases): updateClass auth, role guards, PUT request
- useClassAssignments.test.js (8 cases): removeStudentFromClass, assignStudentToClass
- studentHistoryService.test.js (8 cases): auth, payload, response handling

https://claude.ai/code/session_01FRY3AsFhs7exrpc5b6644f