### PR TITLE
Fix student-facing content bugs in G3 fractions and G4 OAT explanation

### DIFF
--- a/src/content/g3/fractions/__tests__/questions.test.js
+++ b/src/content/g3/fractions/__tests__/questions.test.js
@@ -1,0 +1,72 @@
+import {
+  generateFractionSubtractionQuestion,
+  generateFractionAdditionQuestion,
+  generateEquivalentFractionsQuestion,
+  generateFractionComparisonQuestion,
+  generateFractionSimplificationQuestion,
+} from '../questions.js';
+
+function isNegativeFractionString(s) {
+  if (typeof s !== 'string') return false;
+  if (s.startsWith('-')) return true;
+  // Handle "-N/D" or "N/-D" (just in case)
+  return /^-?\d+\/-?\d+$/.test(s) && s.includes('-');
+}
+
+describe('generateFractionSubtractionQuestion', () => {
+  it('returns a question object with the expected shape', () => {
+    const q = generateFractionSubtractionQuestion();
+
+    expect(q).toHaveProperty('question');
+    expect(q).toHaveProperty('correctAnswer');
+    expect(q).toHaveProperty('questionType');
+    expect(q).toHaveProperty('options');
+    expect(q.concept).toBe('Fractions');
+    expect(q.grade).toBe('G3');
+    expect(q.subtopic).toBe('subtraction');
+  });
+
+  it('never produces a negative-fraction answer across many runs', () => {
+    // Without the fix, the generator could pick (1/3) - (4/5), yielding -7/15.
+    // The fix swaps operands so the minuend is always >= the subtrahend.
+    for (let i = 0; i < 500; i++) {
+      const q = generateFractionSubtractionQuestion(Math.random());
+      expect(isNegativeFractionString(q.correctAnswer)).toBe(false);
+    }
+  });
+
+  it("answer always equals the question's left-fraction minus right-fraction", () => {
+    for (let i = 0; i < 200; i++) {
+      const q = generateFractionSubtractionQuestion(Math.random());
+      const match = q.question.match(
+        /What is (\d+)\/(\d+) - (\d+)\/(\d+)\?/
+      );
+      expect(match).not.toBeNull();
+      const [, n1, d1, n2, d2] = match.map(Number);
+      // Both fractions are proper.
+      expect(n1).toBeLessThan(d1);
+      expect(n2).toBeLessThan(d2);
+      // Minuend >= subtrahend (no negative answer).
+      expect(n1 * d2).toBeGreaterThanOrEqual(n2 * d1);
+    }
+  });
+});
+
+describe('basic 3rd-grade fraction generators (smoke tests)', () => {
+  const generators = [
+    ['generateFractionAdditionQuestion', generateFractionAdditionQuestion],
+    ['generateEquivalentFractionsQuestion', generateEquivalentFractionsQuestion],
+    ['generateFractionComparisonQuestion', generateFractionComparisonQuestion],
+    ['generateFractionSimplificationQuestion', generateFractionSimplificationQuestion],
+  ];
+
+  for (const [name, gen] of generators) {
+    it(`${name} returns a non-empty question and correctAnswer`, () => {
+      const q = gen();
+      expect(typeof q.question).toBe('string');
+      expect(q.question.length).toBeGreaterThan(0);
+      expect(q.correctAnswer).toBeDefined();
+      expect(`${q.correctAnswer}`.length).toBeGreaterThan(0);
+    });
+  }
+});

--- a/src/content/g3/fractions/questions.js
+++ b/src/content/g3/fractions/questions.js
@@ -186,6 +186,13 @@ export function generateFractionSubtractionQuestion(difficulty = 0.5) {
   let num1 = getRandomInt(1, den1 - 1);
   let num2 = getRandomInt(1, den2 - 1);
 
+  // G3 students should never see a negative-fraction answer. If the larger
+  // fraction is on the right, swap the two operands so the minuend is bigger.
+  if (num1 * den2 < num2 * den1) {
+    [num1, num2] = [num2, num1];
+    [den1, den2] = [den2, den1];
+  }
+
   const common_den = den1 * den2;
   const diff_num = num1 * den2 - num2 * den1;
   const answer = getSimplifiedFraction(diff_num, common_den);

--- a/src/content/g4/operations-algebraic-thinking/Explanation.js
+++ b/src/content/g4/operations-algebraic-thinking/Explanation.js
@@ -129,7 +129,7 @@ const OperationsAlgebraicThinkingExplanation = () => {
         <span style={styles.emoji}>🚦</span><strong>Remember:</strong> Multiplication and Division are like VIPs - they get to go before Addition and Subtraction (unless there are parentheses)!
       </div>
 
-      <h2 style={styles.h2}>� Multiplication Properties</h2>
+      <h2 style={styles.h2}>✖️ Multiplication Properties</h2>
       <p>Special rules that help us solve multiplication problems faster!</p>
       
       <div style={styles.example}>
@@ -158,7 +158,7 @@ const OperationsAlgebraicThinkingExplanation = () => {
         <span style={styles.emoji}>🪄</span><strong>Magic Trick:</strong> Use the Associative Property to look for easy numbers to multiply first, like 2 × 5 = 10!
       </div>
 
-      <h2 style={styles.h2}>�🔢 Prime and Composite Numbers</h2>
+      <h2 style={styles.h2}>🔢 Prime and Composite Numbers</h2>
       <p>Numbers can be organized into special groups based on their factors!</p>
       
       <div style={styles.example}>

--- a/src/content/g4/operations-algebraic-thinking/__tests__/Explanation.test.js
+++ b/src/content/g4/operations-algebraic-thinking/__tests__/Explanation.test.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Explanation from '../Explanation';
+
+describe('OperationsAlgebraicThinkingExplanation', () => {
+  it('renders the top-level page title', () => {
+    render(<Explanation />);
+    expect(
+      screen.getByRole('heading', { level: 1, name: /Operations & Algebraic Thinking/i })
+    ).toBeInTheDocument();
+  });
+
+  it('does not contain the Unicode replacement character in any section heading', () => {
+    // The replacement character U+FFFD shows up as a black diamond / question mark
+    // and means an emoji or character could not be decoded. Two h2 headings used
+    // to ship with broken bytes here — guard against the regression.
+    render(<Explanation />);
+    const headings = screen.getAllByRole('heading');
+    for (const heading of headings) {
+      expect(heading.textContent).not.toContain('�');
+    }
+  });
+
+  it('renders the expected top-level section headings', () => {
+    render(<Explanation />);
+    expect(screen.getByRole('heading', { name: /Multiplicative Comparisons/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /Order of Operations/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /Multiplication Properties/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /Prime and Composite Numbers/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /Factors and Multiples/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /Number Patterns/i })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Two student-facing content bugs were silently degrading the quiz / explanation experience:

1. **G3 fraction subtraction could produce negative answers.** `generateFractionSubtractionQuestion` in `src/content/g3/fractions/questions.js` picks two random fractions with different denominators and subtracts them directly. With operands like `1/3 - 4/5`, the answer was `-7/15` — a negative fraction that a 3rd-grader has not been taught and that does not appear in the multiple-choice distractors. Fix: swap the operands when the right fraction is larger so the minuend is always ≥ the subtrahend.

2. **Two G4 Operations & Algebraic Thinking section headings shipped with broken UTF-8 bytes (`U+FFFD`).** "Multiplication Properties" and "Prime and Composite Numbers" in `src/content/g4/operations-algebraic-thinking/Explanation.js` rendered with the Unicode replacement glyph (the black-diamond `?`) in place of the section emoji. Replaced with `✖️` and removed the orphaned byte, respectively.

## Verification

- New unit tests in `src/content/g3/fractions/__tests__/questions.test.js`:
  - 500 randomized runs of the subtraction generator, asserting no negative answer.
  - 200 runs parsing the question text and asserting `n1 * d2 >= n2 * d1`.
  - Smoke tests for the other G3 fraction generators.
- New tests in `src/content/g4/operations-algebraic-thinking/__tests__/Explanation.test.js`:
  - Renders without crash.
  - No heading contains `U+FFFD` (regression guard).
  - All six section headings are present.
- Full Jest suite: **485 tests passing** (3 pre-existing skipped suites untouched).
- `eslint` clean on all four changed/new files.

## Test plan

- [x] `npm test` (485 passing locally)
- [x] `npx eslint` on changed files
- [ ] CI green on push

https://claude.ai/code/session_01D9mGZK4MTdfjywhAvkYuii

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9mGZK4MTdfjywhAvkYuii)_