### PR TITLE
[codex] Fix fraction answer entry

### DIFF
--- a/src/components/NumberPad.js
+++ b/src/components/NumberPad.js
@@ -6,8 +6,9 @@ import { Delete, X } from 'lucide-react';
  * @param {string} value - Current input value
  * @param {function} onChange - Callback when value changes
  * @param {boolean} disabled - Whether the pad is disabled
+ * @param {boolean} allowFraction - Whether to show a fraction bar instead of decimal point
  */
-const NumberPad = React.memo(({ value, onChange, disabled = false }) => {
+const NumberPad = React.memo(({ value, onChange, disabled = false, allowFraction = false }) => {
   const handleNumberClick = (num) => {
     if (disabled) return;
     onChange(value + num);
@@ -18,6 +19,12 @@ const NumberPad = React.memo(({ value, onChange, disabled = false }) => {
     if (!value.includes('.')) {
       onChange(value === '' || value === '-' ? (value + '0.') : value + '.');
     }
+  };
+
+  const handleFractionClick = () => {
+    if (disabled) return;
+    if (!value || value === '-' || value.includes('/') || value.endsWith('.')) return;
+    onChange(value + '/');
   };
 
   const handleToggleSign = () => {
@@ -78,9 +85,15 @@ const NumberPad = React.memo(({ value, onChange, disabled = false }) => {
         <button onClick={() => handleNumberClick('0')} disabled={disabled} className={`${btnBase} ${numBtn}`}>
           0
         </button>
-        <button onClick={handleDecimalClick} disabled={disabled} className={`${btnBase} ${numBtn} text-2xl`} title="Decimal Point">
-          .
-        </button>
+        {allowFraction ? (
+          <button onClick={handleFractionClick} disabled={disabled} className={`${btnBase} ${numBtn} text-2xl`} title="Fraction Bar">
+            /
+          </button>
+        ) : (
+          <button onClick={handleDecimalClick} disabled={disabled} className={`${btnBase} ${numBtn} text-2xl`} title="Decimal Point">
+            .
+          </button>
+        )}
 
         {/* Actions */}
         <button onClick={handleClear} disabled={disabled} className={`${btnBase} ${actionBtn}`} title="Clear">

--- a/src/components/QuizView.js
+++ b/src/components/QuizView.js
@@ -12,6 +12,7 @@ import NumberPad from './NumberPad';
 import PlaceValueTable from './PlaceValueTable';
 import {
   isNumericQuestion,
+  isFractionAnswer,
   normalizeNumericAnswer,
   isAIEvaluatedQuestion,
   isFillInTheBlanksQuestion,
@@ -60,6 +61,26 @@ const QuizView = ({
   const currentQuestion = geometryQuestions.refreshAngleAdditionDiagram(currentQuiz[currentQuestionIndex]);
   const progressPercentage =
     ((currentQuestionIndex + 1) / currentQuiz.length) * 100;
+  const usesNumericInput =
+    isNumericQuestion(currentQuestion) && currentQuestion.questionType !== QUESTION_TYPES.MULTIPLE_CHOICE;
+  const usesFractionInput = usesNumericInput && isFractionAnswer(currentQuestion.correctAnswer);
+  const isCheckAnswerDisabled =
+    isValidatingDrawing ||
+    (currentQuestion.questionType === 'drawing'
+      ? !drawingImageBase64
+      : currentQuestion.questionType === 'write-in'
+        ? !writeInAnswer.trim()
+        : currentQuestion.questionType === 'drawing-with-text'
+          ? (!drawingImageBase64 || !writeInAnswer.trim())
+          : isFillInTheBlanksQuestion(currentQuestion)
+            ? (() => {
+                const blanks = parseBlanks(currentQuestion.question);
+                return fillInAnswers.length !== blanks.length ||
+                  fillInAnswers.some(ans => !ans || ans.trim() === '');
+              })()
+            : usesFractionInput
+              ? !isFractionAnswer(userAnswer)
+              : (userAnswer === null || userAnswer === ''));
 
   // Filter images by type
   const allQuestionImages = (currentQuestion.images || []).filter(img => !img.type || img.type === 'question' || img.type === 'uploaded');
@@ -385,13 +406,14 @@ const QuizView = ({
               );
             })()}
           </div>
-        ) : isNumericQuestion(currentQuestion) && currentQuestion.questionType !== QUESTION_TYPES.MULTIPLE_CHOICE ? (
+        ) : usesNumericInput ? (
           <div className="mb-6">
             {!isAnswered && (
               <NumberPad
                 value={numericInput}
                 onChange={handleNumericChange}
                 disabled={isAnswered}
+                allowFraction={usesFractionInput}
               />
             )}
             {isAnswered && (
@@ -563,7 +585,7 @@ const QuizView = ({
                 </span>
               ) : userAnswer !== null && userAnswer !== '' ? (
                 <span>
-                  {isNumericQuestion(currentQuestion) && currentQuestion.questionType !== QUESTION_TYPES.MULTIPLE_CHOICE ? 'Your answer' : 'Selected'}:{" "}
+                  {usesNumericInput ? 'Your answer' : 'Selected'}:{" "}
                   <span className="font-bold">
                     {formatMathText(userAnswer)}
                   </span>
@@ -579,7 +601,7 @@ const QuizView = ({
                 </span>
               ) : (
                 <span className="italic text-gray-400">
-                  {isNumericQuestion(currentQuestion) && currentQuestion.questionType !== QUESTION_TYPES.MULTIPLE_CHOICE ? 'Enter a number' :
+                  {usesNumericInput ? (usesFractionInput ? 'Enter a fraction' : 'Enter a number') :
                   currentQuestion.questionType === QUESTION_TYPES.MULTIPLE_CHOICE ? 'Select an answer' : ''}
                 </span>
               )}
@@ -595,22 +617,7 @@ const QuizView = ({
               ) : (
                 <button
                   onClick={checkAnswer}
-                  disabled={
-                    isValidatingDrawing ||
-                    (currentQuestion.questionType === 'drawing'
-                      ? !drawingImageBase64
-                      : currentQuestion.questionType === 'write-in'
-                        ? !writeInAnswer.trim()
-                        : currentQuestion.questionType === 'drawing-with-text'
-                          ? (!drawingImageBase64 || !writeInAnswer.trim())
-                          : isFillInTheBlanksQuestion(currentQuestion)
-                            ? (() => {
-                                const blanks = parseBlanks(currentQuestion.question);
-                                return fillInAnswers.length !== blanks.length ||
-                                       fillInAnswers.some(ans => !ans || ans.trim() === '');
-                              })()
-                            : (userAnswer === null || userAnswer === ''))
-                  }
+                  disabled={isCheckAnswerDisabled}
                   className="w-full bg-brand-mint text-white font-display font-bold py-2 px-6 rounded-button hover:opacity-90 active:scale-95 transition-all duration-200 disabled:bg-gray-300 disabled:cursor-not-allowed text-sm min-h-[40px] flex items-center justify-center gap-2 shadow-sm"
                 >
                   {isValidatingDrawing && (

--- a/src/components/__tests__/NumberPad.test.js
+++ b/src/components/__tests__/NumberPad.test.js
@@ -28,6 +28,12 @@ describe('NumberPad', () => {
       expect(screen.getByTitle('Decimal Point')).toBeInTheDocument();
     });
 
+    it('renders fraction bar button when fraction input is enabled', () => {
+      render(<NumberPad value="" onChange={mockOnChange} allowFraction={true} />);
+      expect(screen.getByTitle('Fraction Bar')).toBeInTheDocument();
+      expect(screen.queryByTitle('Decimal Point')).not.toBeInTheDocument();
+    });
+
     it('renders sign toggle button', () => {
       render(<NumberPad value="" onChange={mockOnChange} />);
       expect(screen.getByTitle('Toggle Positive/Negative')).toBeInTheDocument();
@@ -109,6 +115,32 @@ describe('NumberPad', () => {
       fireEvent.click(screen.getByTitle('Decimal Point'));
 
       expect(mockOnChange).toHaveBeenCalledWith('-0.');
+    });
+  });
+
+  describe('fraction bar', () => {
+    it('adds a fraction bar to a numerator', () => {
+      render(<NumberPad value="5" onChange={mockOnChange} allowFraction={true} />);
+
+      fireEvent.click(screen.getByTitle('Fraction Bar'));
+
+      expect(mockOnChange).toHaveBeenCalledWith('5/');
+    });
+
+    it('prevents multiple fraction bars', () => {
+      render(<NumberPad value="5/1" onChange={mockOnChange} allowFraction={true} />);
+
+      fireEvent.click(screen.getByTitle('Fraction Bar'));
+
+      expect(mockOnChange).not.toHaveBeenCalled();
+    });
+
+    it('does not add a fraction bar to an empty value', () => {
+      render(<NumberPad value="" onChange={mockOnChange} allowFraction={true} />);
+
+      fireEvent.click(screen.getByTitle('Fraction Bar'));
+
+      expect(mockOnChange).not.toHaveBeenCalled();
     });
   });
 
@@ -219,6 +251,14 @@ describe('NumberPad', () => {
       render(<NumberPad value="12" onChange={mockOnChange} disabled={true} />);
 
       fireEvent.click(screen.getByTitle('Decimal Point'));
+
+      expect(mockOnChange).not.toHaveBeenCalled();
+    });
+
+    it('prevents fraction bar click when disabled', () => {
+      render(<NumberPad value="12" onChange={mockOnChange} disabled={true} allowFraction={true} />);
+
+      fireEvent.click(screen.getByTitle('Fraction Bar'));
 
       expect(mockOnChange).not.toHaveBeenCalled();
     });

--- a/src/utils/__tests__/answer-helpers.test.js
+++ b/src/utils/__tests__/answer-helpers.test.js
@@ -1,5 +1,5 @@
 
-const { isNumericQuestion, normalizeNumericAnswer, normalizeMathExpression, validateFillInAnswers } = require('../answer-helpers');
+const { isNumericQuestion, isFractionAnswer, normalizeNumericAnswer, normalizeMathExpression, validateFillInAnswers } = require('../answer-helpers');
 
 describe('isNumericQuestion', () => {
   test('returns true for numeric question with options', () => {
@@ -22,6 +22,22 @@ describe('isNumericQuestion', () => {
     const question = {
       correctAnswer: '3.74'
       // no options
+    };
+    expect(isNumericQuestion(question)).toBe(true);
+  });
+
+  test('returns true for fraction question WITHOUT options', () => {
+    const question = {
+      correctAnswer: '5/12'
+      // no options
+    };
+    expect(isNumericQuestion(question)).toBe(true);
+  });
+
+  test('returns true when all options are fractions', () => {
+    const question = {
+      correctAnswer: '5/12',
+      options: ['5/12', '4/12', '7/12']
     };
     expect(isNumericQuestion(question)).toBe(true);
   });
@@ -55,6 +71,20 @@ describe('isNumericQuestion', () => {
   });
 });
 
+describe('isFractionAnswer', () => {
+  test('detects simple fractions', () => {
+    expect(isFractionAnswer('5/12')).toBe(true);
+    expect(isFractionAnswer('-3/4')).toBe(true);
+    expect(isFractionAnswer(' 10 / 24 ')).toBe(true);
+  });
+
+  test('rejects zero denominators and non-fractions', () => {
+    expect(isFractionAnswer('1/0')).toBe(false);
+    expect(isFractionAnswer('3.5')).toBe(false);
+    expect(isFractionAnswer('five/twelve')).toBe(false);
+  });
+});
+
 describe('normalizeNumericAnswer', () => {
   test('removes commas from numbers', () => {
     expect(normalizeNumericAnswer('4,700')).toBe('4700');
@@ -84,6 +114,13 @@ describe('normalizeNumericAnswer', () => {
 
   test('preserves decimal precision', () => {
     expect(normalizeNumericAnswer('3.14159')).toBe('3.14159');
+  });
+
+  test('normalizes equivalent fractions', () => {
+    expect(normalizeNumericAnswer('10/24')).toBe('5/12');
+    expect(normalizeNumericAnswer(' 6 / 3 ')).toBe('2');
+    expect(normalizeNumericAnswer('-2/4')).toBe('-1/2');
+    expect(normalizeNumericAnswer('2/-4')).toBe('-1/2');
   });
 });
 

--- a/src/utils/answer-helpers.js
+++ b/src/utils/answer-helpers.js
@@ -3,7 +3,26 @@ import { QUESTION_TYPES } from '../constants/shared-constants';
 /** Check if the passed in string is numeric (including negative numbers and decimals and commas) */
 function isNumeric(str) {
   if (typeof str !== 'string') return false;
-  return /^-?\d{1,3}(,\d{3})*(\.\d+)?$/.test(str) || /^-?\d+(\.\d+)?$/.test(str);
+  return (
+    /^-?\d{1,3}(,\d{3})*(\.\d+)?$/.test(str) ||
+    /^-?\d+(\.\d+)?$/.test(str) ||
+    isFractionAnswer(str)
+  );
+}
+
+/**
+ * Checks if a value is a simple numeric fraction like 5/12 or -3/4.
+ * @param {string|number} answer
+ * @returns {boolean}
+ */
+export function isFractionAnswer(answer) {
+  if (answer === null || answer === undefined) return false;
+  const compact = answer.toString().trim().replace(/,/g, '').replace(/\s+/g, '');
+  const match = compact.match(/^-?\d+\/-?\d+$/);
+  if (!match) return false;
+
+  const denominator = Number(compact.split('/')[1]);
+  return denominator !== 0;
 }
 
 /**
@@ -218,6 +237,38 @@ export function normalizeNumericAnswer(answer) {
   
   // Remove commas
   trimmed = trimmed.replace(/,/g, '');
+
+  // Normalize simple fractions to a reduced canonical form.
+  if (isFractionAnswer(trimmed)) {
+    const [rawNumerator, rawDenominator] = trimmed.replace(/\s+/g, '').split('/');
+    let numerator = parseInt(rawNumerator, 10);
+    let denominator = parseInt(rawDenominator, 10);
+
+    if (denominator === 0) return trimmed;
+    if (numerator === 0) return '0';
+
+    if (denominator < 0) {
+      numerator *= -1;
+      denominator *= -1;
+    }
+
+    const gcd = (a, b) => {
+      let left = Math.abs(a);
+      let right = Math.abs(b);
+      while (right !== 0) {
+        const temp = right;
+        right = left % right;
+        left = temp;
+      }
+      return left || 1;
+    };
+
+    const divisor = gcd(numerator, denominator);
+    numerator /= divisor;
+    denominator /= divisor;
+
+    return denominator === 1 ? numerator.toString() : `${numerator}/${denominator}`;
+  }
   
   // Handle decimal numbers (both positive and negative)
   if (trimmed.includes('.')) {
@@ -263,4 +314,3 @@ export function normalizeMathExpression(expression) {
   
   return normalized;
 }
-


### PR DESCRIPTION
## Summary

Fixes fraction questions that have a fraction `correctAnswer` like `5/12` but no answer options. Those questions were not classified as numeric, so the quiz fell through to the multiple-choice renderer with an empty options array, leaving students with no selectable answer controls.

## Changes

- Treat simple fraction strings such as `5/12` and `-3/4` as numeric answers.
- Normalize equivalent fraction answers before comparison, so entries like `10/24` compare correctly with `5/12`.
- Add fraction-entry mode to the number pad, replacing the decimal button with a `/` button for fraction-answer questions.
- Disable `Check Answer` until a complete valid fraction is entered.
- Add focused helper and keypad tests for fraction detection, normalization, and keypad behavior.

## Validation

- `npm test -- --runTestsByPath src/utils/__tests__/answer-helpers.test.js src/components/__tests__/NumberPad.test.js src/components/__tests__/NumberPad.snapshot.test.js --watchAll=false`
- `npm run build`