### PR TITLE
Fix content bugs in G3/G4 question generators and explanations

### DIFF
--- a/src/content/g3/division/__tests__/questions.test.js
+++ b/src/content/g3/division/__tests__/questions.test.js
@@ -1,0 +1,20 @@
+import { generateRemainderQuestion } from '../questions.js';
+
+describe('G3 division: remainder question wording', () => {
+  it('reads as a grammatical English sentence (no missing verb)', () => {
+    for (let i = 0; i < 50; i += 1) {
+      const q = generateRemainderQuestion();
+      // Previously: "What is the remainder when 17 ÷ 5?" — missing "divided by".
+      expect(q.question).toMatch(/is divided by/);
+      expect(q.question).not.toMatch(/when \d+ ÷ \d+\?/);
+    }
+  });
+
+  it('always includes the correct answer in the options', () => {
+    for (let i = 0; i < 50; i += 1) {
+      const q = generateRemainderQuestion();
+      expect(q.options).toContain(q.correctAnswer);
+      expect(q.options.length).toBeGreaterThanOrEqual(2);
+    }
+  });
+});

--- a/src/content/g3/division/questions.js
+++ b/src/content/g3/division/questions.js
@@ -259,7 +259,7 @@ export function generateRemainderQuestion() {
   ];
   
   return {
-    question: `What is the remainder when ${dividend} ÷ ${divisor}?`,
+    question: `What is the remainder when ${dividend} is divided by ${divisor}?`,
     correctAnswer: correctAnswer,
     options: shuffle(generateUniqueOptions(correctAnswer, potentialDistractors)),
     questionType: QUESTION_TYPES.MULTIPLE_CHOICE,

--- a/src/content/g3/fractions/__tests__/questions.test.js
+++ b/src/content/g3/fractions/__tests__/questions.test.js
@@ -1,9 +1,11 @@
 import {
   generateEquivalentFractionsQuestion,
   generateFractionAdditionQuestion,
+  generateFractionComparisonQuestion,
   generateFractionSubtractionQuestion,
   generateFractionSimplificationQuestion,
 } from '../questions.js';
+import { QUESTION_TYPES } from '../../../../constants/shared-constants.js';
 
 describe('G3 fractions: CCSS standards are 3rd-grade', () => {
   it('addition uses a 3.NF.* standard, not 4.NF.*', () => {
@@ -40,6 +42,35 @@ describe('generateEquivalentFractionsQuestion: never picks the original fraction
       expect(match).not.toBeNull();
       const original = `${match[1]}/${match[2]}`;
       expect(q.correctAnswer).not.toBe(original);
+    }
+  });
+});
+
+describe('generateFractionComparisonQuestion: consistent multiple-choice across both branches', () => {
+  it('always returns MULTIPLE_CHOICE with both < and > as options', () => {
+    for (let i = 0; i < 100; i += 1) {
+      const q = generateFractionComparisonQuestion();
+      expect(q.questionType).toBe(QUESTION_TYPES.MULTIPLE_CHOICE);
+      expect(Array.isArray(q.options)).toBe(true);
+      expect(q.options).toEqual(expect.arrayContaining(['<', '>']));
+      expect(['<', '>']).toContain(q.correctAnswer);
+    }
+  });
+});
+
+describe('generateFractionSimplificationQuestion: avoids degenerate / colliding distractors', () => {
+  it('does not emit "0/N" distractors and does not include the correct answer as a distractor', () => {
+    for (let i = 0; i < 300; i += 1) {
+      const q = generateFractionSimplificationQuestion();
+      for (const opt of q.options) {
+        // "0/anything" looks malformed to a student. The simplified form of 0
+        // is just "0" (no slash), which is allowed.
+        expect(opt).not.toMatch(/^0\/\d+$/);
+      }
+      // Options are unique and the correct answer appears exactly once.
+      const correctOccurrences = q.options.filter((o) => o === q.correctAnswer).length;
+      expect(correctOccurrences).toBe(1);
+      expect(new Set(q.options).size).toBe(q.options.length);
     }
   });
 });

--- a/src/content/g3/fractions/questions.js
+++ b/src/content/g3/fractions/questions.js
@@ -115,7 +115,8 @@ export function generateFractionComparisonQuestion(difficulty = 0.5) {
     return {
       question: `Which symbol makes this true? ${comp_num1}/${comp_den} ___ ${comp_num2}/${comp_den}`,
       correctAnswer: correctAnswer,
-      questionType: QUESTION_TYPES.FILL_IN_THE_BLANKS,
+      options: shuffle(generateUniqueOptions(correctAnswer, ["<", ">"])),
+      questionType: QUESTION_TYPES.MULTIPLE_CHOICE,
       hint: "If the bottom numbers are the same, the fraction with the bigger top number is greater.",
       standard: "3.NF.A.3.d",
       concept: "Fractions",
@@ -225,10 +226,24 @@ export function generateFractionSimplificationQuestion(difficulty = 0.5) {
   const starting_num = num * multiplier;
   const starting_den = den * multiplier;
   const simplified_fraction = getSimplifiedFraction(starting_num, starting_den);
+  // Build the "off-by-one numerator" distractor without ever producing "0/N"
+  // (visually weird) — shift away from zero when subtraction would land on 0.
+  const numShift = getRandomInt(1, Math.max(1, num - 1));
+  const shiftedNum = num - numShift > 0 ? num - numShift : num + numShift;
+  // The "halved both" distractor can simplify to the same value as the
+  // correct answer (e.g., 8/12 → 4/6 → 2/3, same as the correct 2/3). Use a
+  // genuinely different fraction in that case.
+  const halvedDistractor = getSimplifiedFraction(
+    Math.floor(starting_num / 2),
+    Math.floor(starting_den / 2)
+  );
+  const safeHalvedDistractor = halvedDistractor === simplified_fraction
+    ? `${num + 1}/${den + 1}`
+    : halvedDistractor;
   const potentialDistractors = [
     `${num}/${den + getRandomInt(1, 3)}`,
-    `${Math.abs(num - getRandomInt(1, 3))}/${den}`,
-    getSimplifiedFraction(Math.floor(starting_num / 2), Math.floor(starting_den / 2)),
+    `${shiftedNum}/${den}`,
+    safeHalvedDistractor,
   ];
 
   return {

--- a/src/content/g3/multiplication/__tests__/questions.test.js
+++ b/src/content/g3/multiplication/__tests__/questions.test.js
@@ -1,0 +1,31 @@
+import { generateFactFamilyQuestion } from '../questions.js';
+
+describe('G3 multiplication: fact family never asks a trivially identical commutative question', () => {
+  it('never asks "If A x A = X, what is A x A?"', () => {
+    let commutativeSeen = 0;
+    for (let i = 0; i < 400; i += 1) {
+      const q = generateFactFamilyQuestion();
+      // Only the commutative branch has × on BOTH sides of the comma — the
+      // inverse branches use ÷ on the right side.
+      const commutativeMatch = q.question.match(
+        /^If (\d+) × (\d+) = \d+, what is (\d+) × (\d+)\?$/
+      );
+      if (!commutativeMatch) continue;
+      commutativeSeen += 1;
+      const [, a, b, c, d] = commutativeMatch;
+      // The two factors must differ (or the question is the trivial
+      // "If 4×4=16, what is 4×4?").
+      expect(a).not.toBe(b);
+      expect(c).not.toBe(d);
+      // The commutative branch always asks for the swap, so {a,b} == {c,d}.
+      expect(new Set([a, b])).toEqual(new Set([c, d]));
+      [a, b, c, d].forEach((n) => {
+        expect(Number(n)).toBeGreaterThanOrEqual(2);
+        expect(Number(n)).toBeLessThanOrEqual(9);
+      });
+    }
+    // The generator picks the commutative branch ~1/3 of the time, so we
+    // should have hit it many times in 400 iterations.
+    expect(commutativeSeen).toBeGreaterThan(0);
+  });
+});

--- a/src/content/g3/multiplication/questions.js
+++ b/src/content/g3/multiplication/questions.js
@@ -184,7 +184,12 @@ export function generateEqualGroupsQuestion() {
  */
 export function generateFactFamilyQuestion() {
   const factor1 = getRandomInt(2, 9);
-  const factor2 = getRandomInt(2, 9);
+  // factor2 must differ from factor1: when they're equal the commutative
+  // question "If 4 × 4 = 16, what is 4 × 4?" is trivial (the same expression).
+  let factor2 = getRandomInt(2, 9);
+  while (factor2 === factor1) {
+    factor2 = getRandomInt(2, 9);
+  }
   const product = factor1 * factor2;
   
   const questionTypes = [

--- a/src/content/g4/fractions/__tests__/questions.test.js
+++ b/src/content/g4/fractions/__tests__/questions.test.js
@@ -1,5 +1,8 @@
 import {
   generateFractionSubtractionQuestion,
+  generateFractionComparisonQuestion,
+  generateFractionMultiplicationQuestion,
+  generateMixedNumbersQuestion,
 } from '../questions.js';
 
 describe('G4 fractions: subtraction hint matches the question setup', () => {
@@ -21,6 +24,63 @@ describe('G4 fractions: subtraction hint matches the question setup', () => {
       // Sanity check on the denominators picked
       expect(Number(denom1)).toBeGreaterThan(0);
       expect(Number(denom2)).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('G4 fractions: subtraction never shows "undefined" as a multiple-choice option', () => {
+  it('options never contain the literal string "undefined" (would appear when distractor divides by 0)', () => {
+    // Force the equal-denominator case to occur frequently by running many
+    // iterations — the bug only triggers when denominator === denominator2.
+    for (let i = 0; i < 500; i += 1) {
+      const q = generateFractionSubtractionQuestion(0.5);
+      expect(q.options).not.toContain('undefined');
+      // Sanity: correct answer must be in the options.
+      expect(q.options).toContain(q.correctAnswer);
+    }
+  });
+});
+
+describe('G4 fractions: comparison correctly handles equivalent-but-different-looking fractions', () => {
+  it('never picks "<" or ">" when the two fractions are actually equal', () => {
+    for (let i = 0; i < 500; i += 1) {
+      const q = generateFractionComparisonQuestion(0.5);
+      // Question: "Compare these fractions: A/B ___ C/D"
+      const match = q.question.match(/(\d+)\/(\d+) ___ (\d+)\/(\d+)/);
+      expect(match).not.toBeNull();
+      const [, a, b, c, d] = match.map(Number);
+      // Cross-multiply to check equivalence without floating-point error.
+      expect(a * d).not.toBe(c * b);
+      // The chosen comparator must agree with the real ordering.
+      if (q.correctAnswer === '>') {
+        expect(a * d).toBeGreaterThan(c * b);
+      } else if (q.correctAnswer === '<') {
+        expect(a * d).toBeLessThan(c * b);
+      }
+    }
+  });
+});
+
+describe('G4 fractions: multiplication options stay distinct (n*w === n+w guard)', () => {
+  it('correct answer is not duplicated by the "added instead of multiplied" distractor', () => {
+    for (let i = 0; i < 300; i += 1) {
+      const q = generateFractionMultiplicationQuestion(0.5);
+      const correctOccurrences = q.options.filter((o) => o === q.correctAnswer).length;
+      expect(correctOccurrences).toBe(1);
+      expect(new Set(q.options).size).toBe(q.options.length);
+    }
+  });
+});
+
+describe('G4 fractions: mixed-number addition options stay distinct (no-carry case)', () => {
+  it('correct answer is not duplicated by the "forgot to carry" distractor when no carry was needed', () => {
+    for (let i = 0; i < 500; i += 1) {
+      const q = generateMixedNumbersQuestion(0.5);
+      // Only the addMixed branch shows a "+" in the question stem.
+      if (!/\d+ \d+\/\d+ \+ \d+ \d+\/\d+/.test(q.question)) continue;
+      const correctOccurrences = q.options.filter((o) => o === q.correctAnswer).length;
+      expect(correctOccurrences).toBe(1);
+      expect(new Set(q.options).size).toBe(q.options.length);
     }
   });
 });

--- a/src/content/g4/fractions/questions.js
+++ b/src/content/g4/fractions/questions.js
@@ -178,8 +178,15 @@ export function generateFractionSubtractionQuestion(difficulty = 0.5) {
     difference *= -1;
   }
   const simplifiedAnswer = simplifyFraction(difference, denominator * denominator2);
+  // When denominator === denominator2 the "subtract straight across" distractor
+  // would divide by zero (Math.abs(d - d) === 0 → simplifyFraction returns the
+  // literal string 'undefined'). Fall back to a safe alternate distractor in
+  // that case so students never see "undefined" as an answer choice.
+  const subtractStraightDistractor = denominator === denominator2
+    ? simplifyFraction(Math.abs(num1 - num2), denominator)
+    : simplifyFraction(Math.abs(num1 - num2), Math.abs(denominator - denominator2));
   const potentialDistractors = [
-    simplifyFraction(Math.abs(num1 - num2), Math.abs(denominator - denominator2)),
+    subtractStraightDistractor,
     simplifyFraction(difference + 1, denominator * denominator2),
     simplifyFraction(difference, denominator * denominator2 + 1),
   ];
@@ -206,14 +213,21 @@ export function generateFractionSubtractionQuestion(difficulty = 0.5) {
 export function generateFractionComparisonQuestion(difficulty = 0.5) {
   // Scale numerator and denominator ranges by difficulty
   const maxNum = Math.min(10, 4 + Math.floor(difficulty * 6));
+  const maxDen = 10 + Math.floor(difficulty * 5);
   let num1 = getRandomInt(1, maxNum);
-  const den1 = getRandomInt(num1 + 1, 10 + Math.floor(difficulty * 5));
+  let den1 = getRandomInt(num1 + 1, maxDen);
   let num2 = getRandomInt(1, maxNum);
-  const den2 = getRandomInt(num2 + 1, 10 + Math.floor(difficulty * 5));
+  let den2 = getRandomInt(num2 + 1, maxDen);
 
-  // Ensure fractions are different
-  if (num1 / den1 === num2 / den2) {
-    num2 = num1 + 1 <= maxNum ? num1 + 1 : num1 - 1;
+  // Ensure the two fractions have genuinely different values. Bumping only
+  // num2 (the previous behavior) can land on another equivalent fraction
+  // (e.g., 2/4 and 3/6 are both 0.5; bumping num2 to 3 leaves them equal).
+  // Re-roll both num2 and den2 until the cross-multiplied values differ.
+  let safety = 0;
+  while (num1 * den2 === num2 * den1 && safety < 20) {
+    num2 = getRandomInt(1, maxNum);
+    den2 = getRandomInt(num2 + 1, maxDen);
+    safety += 1;
   }
 
   const decimal1 = num1 / den1;
@@ -294,9 +308,16 @@ export function generateFractionMultiplicationQuestion(difficulty = 0.5) {
   
   const resultNumerator = numerator * wholeNumber;
   const simplifiedResult = simplifyFraction(resultNumerator, denominator);
-  
+
+  // The "added instead of multiplied" distractor collides with the answer
+  // when n + w === n * w (e.g., n = w = 2). Skip it in that case and use a
+  // different misconception fallback (multiplied the denominator too).
+  const addedInsteadDistractor = simplifyFraction(numerator + wholeNumber, denominator);
+  const safeAddedDistractor = addedInsteadDistractor === simplifiedResult
+    ? simplifyFraction(resultNumerator, denominator * wholeNumber)
+    : addedInsteadDistractor;
   const potentialDistractors = [
-    simplifyFraction(numerator + wholeNumber, denominator),
+    safeAddedDistractor,
     simplifyFraction(resultNumerator + 1, denominator),
     simplifyFraction(resultNumerator, denominator + 1),
   ];
@@ -390,21 +411,29 @@ export function generateMixedNumbersQuestion(difficulty = 0.5) {
     
     let resultWhole = whole1 + whole2;
     let resultNum = num1 + num2;
-    
+    const carried = resultNum >= denominator;
+
     // Handle carrying
-    if (resultNum >= denominator) {
+    if (carried) {
       resultWhole += 1;
       resultNum -= denominator;
     }
-    
-    const correctAnswer = resultNum === 0 
-      ? `${resultWhole}` 
+
+    const correctAnswer = resultNum === 0
+      ? `${resultWhole}`
       : `${resultWhole} ${resultNum}/${denominator}`;
-    
+
+    // The "forgot to carry" distractor (whole1+whole2, num1+num2 / d) is
+    // identical to the correct answer when no carry was needed, so only emit
+    // it when carrying actually happened. Substitute a different misconception
+    // distractor otherwise.
+    const forgotToCarryDistractor = carried
+      ? `${whole1 + whole2} ${num1 + num2}/${denominator}`
+      : `${resultWhole} ${Math.max(1, resultNum - 1)}/${denominator}`;
     const potentialDistractors = [
-      `${resultWhole + 1} ${resultNum}/${denominator}`,
+      `${resultWhole + 1} ${resultNum === 0 ? 1 : resultNum}/${denominator}`,
       `${resultWhole} ${resultNum + 1}/${denominator}`,
-      `${whole1 + whole2} ${num1 + num2}/${denominator}`,
+      forgotToCarryDistractor,
     ];
     
     return {

--- a/src/content/g4/geometry/Explanation.js
+++ b/src/content/g4/geometry/Explanation.js
@@ -355,7 +355,7 @@ const GeometryExplanation = () => {
             '• 3 angles',
             '• Sum of angles = 180°',
             '• Can be many types (equilateral, isosceles, scalene)',
-            '• Can have lines of symmetry when opposite angles are equal',
+            '• Has lines of symmetry when at least two sides are equal (isosceles)',
             '• Simplest polygon',
             '• Very stable shape'
           ],
@@ -374,7 +374,7 @@ const GeometryExplanation = () => {
           funFact: 'A circle has infinite lines of symmetry - any line through the center!'
         },
         'pentagon-demo': {
-          name: '🔷 Pentagon',
+          name: '🔷 Regular Pentagon',
           properties: [
             '• 5 equal sides',
             '• 5 equal angles',
@@ -386,11 +386,11 @@ const GeometryExplanation = () => {
           funFact: 'The Pentagon building in Washington D.C. is shaped like a pentagon!'
         },
         'hexagon-demo': {
-          name: '⬡ Hexagon',
+          name: '⬡ Regular Hexagon',
           properties: [
             '• 6 equal sides',
             '• 6 equal angles',
-            '• 12 lines of symmetry',
+            '• 6 lines of symmetry',
             '• Sum of angles = 720°',
             '• Each angle = 120°',
             '• Tessellates perfectly'
@@ -943,8 +943,8 @@ const GeometryExplanation = () => {
         <div style={styles.example}>
           <strong>Real Life Angles:</strong>
           <br/>• Corner of a book = 90° (right angle)
-          <br/>• Open scissors = obtuse angle
-          <br/>• Laptop half-open = acute angle
+          <br/>• Open scissors = acute angle
+          <br/>• Laptop half-open = obtuse angle
           <br/>• Flat table = 180° (straight angle)
         </div>
 
@@ -1186,7 +1186,6 @@ const GeometryExplanation = () => {
               <strong>🔧 Parallelogram</strong><br/>
               • Opposite sides equal<br/>
               • Opposite angles equal<br/>
-              • No right angles<br/>
               • Opposite sides parallel<br/>
               <div id="parallelogram-demo" style={{ ...styles.svgContainer, marginTop: '10px' }}></div>
               <small style={{color: '#666', fontStyle: 'italic'}}>Leaning rectangle</small>

--- a/src/content/g4/geometry/__tests__/Explanation.consistency.test.js
+++ b/src/content/g4/geometry/__tests__/Explanation.consistency.test.js
@@ -1,0 +1,51 @@
+import fs from 'fs';
+import path from 'path';
+
+// We can't easily render the Explanation component in jsdom without firing all
+// its lifecycle code, so verify the source text directly for two known
+// regressions: the angle real-life examples must agree with the question
+// generator's classification, and the regular hexagon must list 6 (not 12)
+// lines of symmetry.
+
+const EXPLANATION_PATH = path.join(__dirname, '..', 'Explanation.js');
+const QUESTIONS_PATH = path.join(__dirname, '..', 'questions.js');
+
+const explanationSrc = fs.readFileSync(EXPLANATION_PATH, 'utf8');
+const questionsSrc = fs.readFileSync(QUESTIONS_PATH, 'utf8');
+
+describe('G4 geometry Explanation: agrees with the question generator on angle examples', () => {
+  it('Explanation labels "open scissors" as an acute angle (matches the question bank)', () => {
+    // The questions generator places "open scissors" in the acute realLifeExamples list.
+    expect(questionsSrc).toMatch(/acute[^]*?"open scissors"/);
+    // The Explanation page must agree.
+    expect(explanationSrc).toMatch(/Open scissors\s*=\s*acute angle/);
+    expect(explanationSrc).not.toMatch(/Open scissors\s*=\s*obtuse angle/);
+  });
+
+  it('Explanation labels "laptop half-open" as an obtuse angle (matches the question bank)', () => {
+    expect(questionsSrc).toMatch(/obtuse[^]*?"laptop half-open"/);
+    expect(explanationSrc).toMatch(/Laptop half-open\s*=\s*obtuse angle/);
+    expect(explanationSrc).not.toMatch(/Laptop half-open\s*=\s*acute angle/);
+  });
+});
+
+describe('G4 geometry Explanation: regular polygon symmetry counts', () => {
+  it('says a regular hexagon has 6 (not 12) lines of symmetry', () => {
+    // The D6 dihedral group has 12 symmetries (6 rotations + 6 reflections),
+    // but only the 6 reflections count as lines of symmetry. Grab the popup
+    // definition block (the object literal under shapeProperties), not the
+    // earlier id reference where the shape SVG is constructed.
+    const hexPopup = explanationSrc.match(
+      /'hexagon-demo':\s*\{[\s\S]{0,500}?funFact[\s\S]{0,200}?\}/
+    );
+    expect(hexPopup).not.toBeNull();
+    expect(hexPopup[0]).toMatch(/6 lines of symmetry/);
+    expect(hexPopup[0]).not.toMatch(/12 lines of symmetry/);
+  });
+});
+
+describe('G4 geometry Explanation: parallelogram does not falsely exclude right angles', () => {
+  it('does not claim a parallelogram has "No right angles" (a rectangle is a parallelogram)', () => {
+    expect(explanationSrc).not.toMatch(/Parallelogram[\s\S]{0,400}No right angles/);
+  });
+});

--- a/src/content/g4/measurement-data/__tests__/questions.test.js
+++ b/src/content/g4/measurement-data/__tests__/questions.test.js
@@ -3,6 +3,7 @@ import {
   generateWeightCapacityConversionQuestion,
   generateTimeConversionQuestion,
   generateClockReadingQuestion,
+  generateAreaPerimeterQuestion,
 } from '../questions.js';
 
 // Mock the clock SVG generator so the tests don't depend on its output.
@@ -132,3 +133,27 @@ describe('generateClockReadingQuestion swapped-hands distractor', () => {
     }
   });
 });
+
+describe('generateAreaPerimeterQuestion: avoids l*w === 2*(l+w) collision', () => {
+  // When length × width === 2 × (length + width) (e.g., 4×4 area=perim=16,
+  // 6×3 area=perim=18), the "swap-the-formula" distractor collapses into the
+  // correct answer and the option count drops below 4 after dedupe.
+  it('always has the correct answer present exactly once and at least 3 unique options', () => {
+    for (let i = 0; i < 500; i += 1) {
+      const q = generateAreaPerimeterQuestion(0.5);
+      expect(q.options).toContain(q.correctAnswer);
+      const correctOccurrences = q.options.filter((o) => o === q.correctAnswer).length;
+      expect(correctOccurrences).toBe(1);
+      // Options must be unique.
+      expect(new Set(q.options).size).toBe(q.options.length);
+      // Verify the rectangle dimensions don't fall into the degenerate case.
+      const dimsMatch = q.question.match(/length of (\d+) units and a width of (\d+) units/);
+      expect(dimsMatch).not.toBeNull();
+      const [, lengthStr, widthStr] = dimsMatch;
+      const l = Number(lengthStr);
+      const w = Number(widthStr);
+      expect(l * w).not.toBe(2 * (l + w));
+    }
+  });
+});
+

--- a/src/content/g4/measurement-data/questions.js
+++ b/src/content/g4/measurement-data/questions.js
@@ -226,13 +226,22 @@ export function generateTimeConversionQuestion(difficulty = 0.5) {
  * @param {string} requestedSubtopic - Optional: 'area' or 'perimeter' to force a specific type
  */
 export function generateAreaPerimeterQuestion(difficulty = 0.5, requestedSubtopic = null) {
-  const rectLength = getRandomInt(4, 12);
-  const rectWidth = getRandomInt(3, 8);
+  // Re-roll dimensions when length×width === 2×(length+width). At those
+  // dimensions (4×4, 6×3, 3×6, ...) the "swapped formula" distractor
+  // becomes equal to the correct answer and the option count collapses
+  // after dedupe. Bounded loop so we never spin forever.
+  let rectLength, rectWidth;
+  let attempts = 0;
+  do {
+    rectLength = getRandomInt(4, 12);
+    rectWidth = getRandomInt(3, 8);
+    attempts += 1;
+  } while (rectLength * rectWidth === 2 * (rectLength + rectWidth) && attempts < 10);
   // If a specific subtopic is requested, use it; otherwise random
-  const isAreaQuestion = requestedSubtopic === 'area' 
-    ? true 
-    : requestedSubtopic === 'perimeter' 
-    ? false 
+  const isAreaQuestion = requestedSubtopic === 'area'
+    ? true
+    : requestedSubtopic === 'perimeter'
+    ? false
     : Math.random() < 0.5;
   const correctAnswerVal = isAreaQuestion
     ? rectLength * rectWidth


### PR DESCRIPTION
## Summary

Audited every topic/subtopic question generator and the geometry explanation for issues that would directly degrade the student experience, then fixed each one with a regression test.

### High-impact bug fixes

**G4 Fractions (`src/content/g4/fractions/questions.js`)**
- **Subtraction shows literal "undefined" as a choice.** When the two denominators happened to be equal, a distractor became `simplifyFraction(_, 0)` → the string `"undefined"`. Use a safe alternate distractor in that case.
- **Comparison guard didn't actually pick a different fraction.** `if (num1/den1 === num2/den2)` then only bumped `num2`, so equivalent-but-different pairs (e.g., `2/4` vs `3/6`) still got through with the wrong comparator. Re-roll until cross-products differ.
- **Multiplication self-collision.** The "added instead of multiplied" distractor `(n + w)/d` equals the correct answer when `n + w === n * w` (notably `n = w = 2`). Fall back to a different misconception distractor.
- **Mixed-number addition self-collision in the no-carry branch.** `${whole1+whole2} ${num1+num2}/${denominator}` is identical to the correct answer whenever no carry was needed. Only emit it when carrying actually happened.

**G4 Measurement & Data (`src/content/g4/measurement-data/questions.js`)**
- **Area/perimeter swap-formula collision.** For `4×4` and `6×3`, `length × width === 2 × (length + width)`, so the "wrong formula" distractor equals the correct answer and the option count collapses below 4. Re-roll dimensions when this would happen.

**G4 Geometry Explanation (`src/content/g4/geometry/Explanation.js`)**
- **Angle examples contradicted the question generator.** The explanation said "Open scissors = obtuse" and "Laptop half-open = acute"; the question bank uses the opposite. Students were graded as wrong on the same example the lesson taught. Aligned the explanation to the question bank.
- **Hexagon symmetry count.** A regular hexagon has 6 lines of symmetry (the D6 group has 12 *symmetries* total but only 6 reflections). Fixed.
- **Parallelogram "No right angles" contradicted the shape hierarchy.** The same page also teaches that "a rectangle is a special parallelogram", which has right angles. Removed the line.
- **Triangle "opposite angles" claim.** Triangles don't have opposite angles; replaced with the correct condition (at least two sides equal → isosceles).

**G3 Multiplication (`src/content/g3/multiplication/questions.js`)**
- **Fact-family trivial commutative.** When `factor1 === factor2`, the commutative branch read "If 4 × 4 = 16, what is 4 × 4?". Re-roll `factor2` so it differs from `factor1`.

**G3 Division (`src/content/g3/division/questions.js`)**
- **Missing verb in question stem.** "What is the remainder when 17 ÷ 5?" → "What is the remainder when 17 is divided by 5?".

**G3 Fractions (`src/content/g3/fractions/questions.js`)**
- **Inconsistent question type for `<` / `>` comparison.** The same-denominator branch returned `FILL_IN_THE_BLANKS` with no options array; the same-numerator branch returned `MULTIPLE_CHOICE`. Both branches now use `MULTIPLE_CHOICE` with `<` / `>` options.
- **Simplification distractors.** Avoid emitting `0/N` distractors when shifting the numerator, and substitute a different distractor when the "halved both" distractor simplifies to the same value as the correct answer (e.g., `8/12 → 4/6 → 2/3` would have been the same as the correct `2/3`).

### Tests

- New: `src/content/g3/division/__tests__/questions.test.js`
- New: `src/content/g3/multiplication/__tests__/questions.test.js`
- New: `src/content/g4/geometry/__tests__/Explanation.consistency.test.js`
- Extended: `src/content/g3/fractions/__tests__/questions.test.js`
- Extended: `src/content/g4/fractions/__tests__/questions.test.js`
- Extended: `src/content/g4/measurement-data/__tests__/questions.test.js`

## Test plan

- [x] All existing content tests pass (84 → 98 passing in `src/content/`)
- [x] Full unit test suite passes (`npm test --watchAll=false` → 528 passed, 4 skipped, 0 failed)
- [ ] CI run on this PR is green


---
_Generated by [Claude Code](https://claude.ai/code/session_01JdPTWFJe7KJjAnV3iwhkiv)_