### PR TITLE
Fix student-facing content bugs across G3/G4 question generators

### DIFF
--- a/src/content/g3/division/__tests__/questions.test.js
+++ b/src/content/g3/division/__tests__/questions.test.js
@@ -17,4 +17,16 @@ describe('G3 division: remainder question wording', () => {
       expect(q.options.length).toBeGreaterThanOrEqual(2);
     }
   });
+
+  it('always produces 4 distinct options (no distractor collision when remainder+1 === divisor)', () => {
+    // Bug: when remainder === divisor - 1 (common — ~1/3 of the time when
+    // divisor=3), the naive distractors [remainder+1, remainder-1, divisor]
+    // included `divisor` twice, causing generateUniqueOptions to silently
+    // drop a duplicate and leave only 3 options.
+    for (let i = 0; i < 500; i += 1) {
+      const q = generateRemainderQuestion();
+      expect(new Set(q.options).size).toBe(q.options.length);
+      expect(q.options.length).toBe(4);
+    }
+  });
 });

--- a/src/content/g3/division/questions.js
+++ b/src/content/g3/division/questions.js
@@ -252,8 +252,22 @@ export function generateRemainderQuestion() {
   const dividend = quotient * divisor + remainder;
 
   const correctAnswer = remainder.toString();
+  // When remainder === divisor - 1, the naive distractors [remainder+1, ...,
+  // divisor] contain two copies of `divisor`, which generateUniqueOptions
+  // silently dedupes — leaving fewer than 4 options. Swap in a fallback that
+  // is guaranteed different from `divisor`, `remainder`, and the low
+  // distractor.
+  let highDistractor = remainder + 1;
+  if (highDistractor === divisor) {
+    const lowFallback = remainder - 1;
+    // Prefer the quotient; fall back to divisor+1 if quotient would collide
+    // with the correct answer or the other distractors.
+    highDistractor = (quotient !== remainder && quotient !== divisor && quotient !== lowFallback)
+      ? quotient
+      : divisor + 1;
+  }
   const potentialDistractors = [
-    (remainder + 1).toString(),
+    highDistractor.toString(),
     (remainder - 1 >= 0 ? remainder - 1 : remainder + 1).toString(),
     divisor.toString(),
   ];

--- a/src/content/g3/fractions/__tests__/questions.test.js
+++ b/src/content/g3/fractions/__tests__/questions.test.js
@@ -44,6 +44,19 @@ describe('generateEquivalentFractionsQuestion: never picks the original fraction
       expect(q.correctAnswer).not.toBe(original);
     }
   });
+
+  it('never produces a whole-number "fraction" like 10/10 at high difficulty', () => {
+    // At difficulty=1 the old code would allow f_num_eq = 10 with the
+    // denominator forced to 10, producing "Which fraction is equivalent to
+    // 10/10?" — a degenerate whole number written as a fraction.
+    for (let i = 0; i < 500; i += 1) {
+      const q = generateEquivalentFractionsQuestion(1);
+      const match = q.question.match(/equivalent to (\d+)\/(\d+)\?/);
+      expect(match).not.toBeNull();
+      const [, num, den] = match.map(Number);
+      expect(num).toBeLessThan(den);
+    }
+  });
 });
 
 describe('generateFractionComparisonQuestion: consistent multiple-choice across both branches', () => {

--- a/src/content/g3/fractions/questions.js
+++ b/src/content/g3/fractions/questions.js
@@ -67,7 +67,11 @@ export function generateQuestion(difficulty = 0.5, allowedSubtopics = null) {
 
 export function generateEquivalentFractionsQuestion(difficulty = 0.5) {
   const minNum = 1 + Math.floor(4 * difficulty);
-  const maxNum = 5 + Math.floor(5 * difficulty);
+  // Clamp numerator at 8 so `f_den_eq = getRandomInt(f_num_eq + 1, 9)` always
+  // has a valid range — otherwise at high difficulty we can produce
+  // degenerate fractions like 10/10 (equal to 1) whose "equivalent" answer
+  // is 20/20.
+  const maxNum = Math.min(8, 5 + Math.floor(5 * difficulty));
   const f_num_eq = getRandomInt(minNum, maxNum);
   const f_den_eq = getRandomInt(f_num_eq + 1, 9);
   // Multiplier must be at least 2 so the "equivalent" answer is a different

--- a/src/content/g3/measurement-data/__tests__/questions.test.js
+++ b/src/content/g3/measurement-data/__tests__/questions.test.js
@@ -1,0 +1,58 @@
+import {
+  generateAreaQuestion,
+  generateVolumeQuestion,
+  generatePerimeterQuestion,
+} from '../questions.js';
+
+describe('G3 measurement-data: area distractors never collide with the correct area', () => {
+  it('always produces 4 distinct options', () => {
+    // The perimeter distractor 2*(l+w) equals the area l*w for (l,w) in
+    // {(3,6), (4,4), (6,3)} — all within the generator's range. Run many
+    // iterations to exercise those cases and verify the fix keeps the option
+    // pool at 4 distinct values.
+    for (let i = 0; i < 500; i += 1) {
+      const q = generateAreaQuestion();
+      expect(q.options).toContain(q.correctAnswer);
+      expect(new Set(q.options).size).toBe(q.options.length);
+      expect(q.options.length).toBe(4);
+    }
+  });
+
+  it('never produces a negative or zero option', () => {
+    for (let i = 0; i < 200; i += 1) {
+      const q = generateAreaQuestion();
+      q.options.forEach((opt) => {
+        const value = parseInt(opt, 10);
+        expect(value).toBeGreaterThan(0);
+      });
+    }
+  });
+});
+
+describe('G3 measurement-data: volume distractors never collide with the correct volume', () => {
+  it('always produces 4 distinct options', () => {
+    // The l+w+h distractor equals l*w*h for (3,2,1) etc. — both = 6.
+    // Also l+w+h could equal volume-2. Run many iterations to exercise these.
+    for (let i = 0; i < 500; i += 1) {
+      const q = generateVolumeQuestion();
+      expect(q.options).toContain(q.correctAnswer);
+      expect(new Set(q.options).size).toBe(q.options.length);
+      expect(q.options.length).toBe(4);
+    }
+  });
+});
+
+describe('G3 measurement-data: perimeter question sanity', () => {
+  it('always produces 4 distinct options and matches the computed perimeter', () => {
+    for (let i = 0; i < 200; i += 1) {
+      const q = generatePerimeterQuestion();
+      const match = q.question.match(/sides of length (\d+) inches and (\d+) inches/);
+      expect(match).not.toBeNull();
+      const [, s1, s2] = match.map(Number);
+      const expected = `${2 * (s1 + s2)} inches`;
+      expect(q.correctAnswer).toBe(expected);
+      expect(q.options).toContain(q.correctAnswer);
+      expect(new Set(q.options).size).toBe(q.options.length);
+    }
+  });
+});

--- a/src/content/g3/measurement-data/questions.js
+++ b/src/content/g3/measurement-data/questions.js
@@ -58,10 +58,16 @@ export function generateAreaQuestion() {
   const md_length = getRandomInt(3, 15);
   const md_width = getRandomInt(3, 10);
   const area = md_length * md_width;
+  const perimeter = (md_length + md_width) * 2;
+  const sumSides = md_length + md_width;
   const correctAnswer = `${area} cm²`;
+  // Perimeter distractor equals the area for pairs like (3,6), (4,4), (6,3).
+  // Shift by +2 whenever the "perimeter as area" distractor would collide.
+  const perimeterDistractor = perimeter === area ? perimeter + 2 : perimeter;
+  const sumDistractor = sumSides === area ? sumSides + 1 : sumSides;
   const potentialDistractors = [
-    `${(md_length + md_width) * 2} cm²`,
-    `${md_length + md_width} cm²`,
+    `${perimeterDistractor} cm²`,
+    `${sumDistractor} cm²`,
     `${area + 10} cm²`,
   ];
 
@@ -106,9 +112,20 @@ export function generateVolumeQuestion() {
   const vol_w = getRandomInt(2, 4);
   const vol_h = getRandomInt(1, 3);
   const volume = vol_l * vol_w * vol_h;
+  const sumDims = vol_l + vol_w + vol_h;
+  // Sum of dimensions equals the volume for (3,2,1) etc., and can collide with
+  // the "volume - 2" distractor (e.g. 2×2×2 → volume=8, sum=5, volume-2=6 but
+  // 2×3×1 → volume=6, sum=6). Shift the sum distractor if it collides with any
+  // of the other displayed answers.
+  const collidesWithVolume = sumDims === volume;
+  const collidesWithMinus2 = sumDims === volume - 2;
+  const collidesWithPlus5 = sumDims === volume + 5;
+  const sumDistractor = collidesWithVolume || collidesWithMinus2 || collidesWithPlus5
+    ? volume + 1
+    : sumDims;
   const correctAnswer = `${volume} cubes`;
   const potentialDistractors = [
-    `${vol_l + vol_w + vol_h} cubes`,
+    `${sumDistractor} cubes`,
     `${volume + 5} cubes`,
     `${volume - 2} cubes`,
   ];

--- a/src/content/g4/base-ten/__tests__/questions.test.js
+++ b/src/content/g4/base-ten/__tests__/questions.test.js
@@ -1,0 +1,64 @@
+import {
+  generateRoundingQuestion,
+  generateAdditionWordProblemQuestion,
+} from '../questions.js';
+
+describe('G4 base-ten: rounding never shows negative multiple-choice options', () => {
+  it('does not emit negative-number distractors at any difficulty', () => {
+    // At high difficulty the number could still be relatively small (e.g.
+    // 11,234) while the selected place could be "millions" (divisor
+    // 1,000,000). The old code would emit `rounded - divisor` = -1,000,000
+    // as a distractor. Run many iterations across the difficulty band.
+    const difficulties = [0.0, 0.3, 0.5, 0.8, 1.0];
+    for (const d of difficulties) {
+      for (let i = 0; i < 300; i += 1) {
+        const q = generateRoundingQuestion(d);
+        for (const opt of q.options) {
+          const value = parseInt(opt, 10);
+          expect(value).toBeGreaterThan(0);
+        }
+      }
+    }
+  });
+
+  it('correct answer is always in options and options are distinct', () => {
+    for (let i = 0; i < 300; i += 1) {
+      const q = generateRoundingQuestion(1.0);
+      expect(q.options).toContain(q.correctAnswer);
+      expect(new Set(q.options).size).toBe(q.options.length);
+    }
+  });
+});
+
+describe('G4 base-ten: addition word problem — library scenario mentions the correct item types', () => {
+  it('the "how many altogether" closing sentence uses the item types that appear in the setup', () => {
+    // The old scenario hardcoded "How many books and magazines do they have
+    // altogether?" even when the collection types were e.g. ["novels",
+    // "textbooks"] — nonsense because there are no magazines in the setup.
+    const libraryQuestions = [];
+    for (let i = 0; i < 500; i += 1) {
+      const q = generateAdditionWordProblemQuestion(0.5);
+      const setupMatch = q.question.match(/Library has [\d,]+ ([\w' ]+?) and [\d,]+ ([\w' ]+?)\./);
+      if (setupMatch) {
+        libraryQuestions.push({ question: q.question, type1: setupMatch[1], type2: setupMatch[2] });
+      }
+    }
+    expect(libraryQuestions.length).toBeGreaterThan(0);
+    // Any library question whose setup does NOT use magazines must not fall
+    // back to the old "books and magazines" closing sentence.
+    const nonMagazine = libraryQuestions.filter(
+      ({ type1, type2 }) => type1 !== 'fiction books' || type2 !== 'magazines'
+    );
+    const mismatchedClosings = nonMagazine.filter(({ question }) =>
+      /How many books and magazines do they have altogether\?/.test(question)
+    );
+    expect(mismatchedClosings).toEqual([]);
+    // The closing sentence should mention the actual types for every library
+    // question.
+    const closingMismatches = libraryQuestions.filter(({ question, type1, type2 }) => {
+      const closeRegex = new RegExp(`How many ${type1} and ${type2} do they have altogether\\?`);
+      return !closeRegex.test(question);
+    });
+    expect(closingMismatches).toEqual([]);
+  });
+});

--- a/src/content/g4/base-ten/questions.js
+++ b/src/content/g4/base-ten/questions.js
@@ -235,14 +235,25 @@ export function generateRoundingQuestion(difficulty = 0.5) {
     { name: "millions", divisor: 1000000 }
   ];
   
-  // Select rounding place based on difficulty (easier = smaller places)
-  const maxIndex = Math.min(5, Math.floor(difficulty * 6));
+  // Select rounding place based on difficulty (easier = smaller places).
+  // Also cap the maximum place at the largest divisor whose next digit fits in
+  // the number — otherwise "round 6,234 to the nearest million" produces a
+  // correct answer of 0, and the "rounded - divisor" distractor goes negative.
+  const availableIndex = roundingOptions.reduce(
+    (max, opt, idx) => (number >= opt.divisor ? idx : max),
+    0
+  );
+  const maxIndex = Math.min(5, Math.floor(difficulty * 6), availableIndex);
   const roundTo = roundingOptions[getRandomInt(0, maxIndex)];
   const rounded = Math.round(number / roundTo.divisor) * roundTo.divisor;
   const correctAnswer = rounded.toString();
+  // Filter out negative or zero distractors — students shouldn't see negatives
+  // in a rounding problem, and 0 collides with the correct answer only when
+  // `rounded === roundTo.divisor` (rare given the guard above).
+  const roundedMinus = rounded - roundTo.divisor;
   const potentialDistractors = [
     (rounded + roundTo.divisor).toString(),
-    (rounded - roundTo.divisor).toString(),
+    roundedMinus > 0 ? roundedMinus.toString() : (rounded + 2 * roundTo.divisor).toString(),
     (number).toString(),
   ];
 
@@ -636,7 +647,7 @@ export function generateAdditionWordProblemQuestion(difficulty = 0.5) {
     {
       context: "library collection",
       question: (library, type1, count1, type2, count2, total) =>
-        `${library} Library has ${addCommas(count1)} ${type1} and ${addCommas(count2)} ${type2}. How many books and magazines do they have altogether?`
+        `${library} Library has ${addCommas(count1)} ${type1} and ${addCommas(count2)} ${type2}. How many ${type1} and ${type2} do they have altogether?`
     },
     {
       context: "votes",

--- a/src/content/g4/fractions/__tests__/questions.test.js
+++ b/src/content/g4/fractions/__tests__/questions.test.js
@@ -41,6 +41,24 @@ describe('G4 fractions: subtraction never shows "undefined" as a multiple-choice
   });
 });
 
+describe('G4 fractions: subtraction distractor pool stays distinct in the equal-denominator case', () => {
+  it('always produces 4 unique options — the equal-denom "subtract straight across" distractor used to equal the correct answer', () => {
+    // When denominator === denominator2 the previous "subtract straight
+    // across" distractor was simplifyFraction(|num1-num2|, denominator),
+    // which IS the correct answer for equal-denominator subtraction. The
+    // duplicate got dropped by generateUniqueOptions, leaving only 3 options.
+    // Run at difficulty 0.4 where the denominator range is smallest so the
+    // equal-denominator case is likely.
+    for (let i = 0; i < 500; i += 1) {
+      const q = generateFractionSubtractionQuestion(0.4);
+      const correctOccurrences = q.options.filter((o) => o === q.correctAnswer).length;
+      expect(correctOccurrences).toBe(1);
+      expect(new Set(q.options).size).toBe(q.options.length);
+      expect(q.options.length).toBe(4);
+    }
+  });
+});
+
 describe('G4 fractions: comparison correctly handles equivalent-but-different-looking fractions', () => {
   it('never picks "<" or ">" when the two fractions are actually equal', () => {
     for (let i = 0; i < 500; i += 1) {

--- a/src/content/g4/fractions/questions.js
+++ b/src/content/g4/fractions/questions.js
@@ -172,24 +172,70 @@ export function generateFractionSubtractionQuestion(difficulty = 0.5) {
   let num2 = getRandomInt(2, denominator2 - 1);
 
   let difference = num1 * denominator2 - num2 * denominator;
-  if (difference <= 0) {
+  // If the two fractions are equal, the "answer" is 0 and several distractor
+  // formulas also evaluate to 0, collapsing the option pool. Nudge num1 by 1
+  // (either direction) to guarantee a non-zero difference.
+  if (difference === 0) {
+    if (num1 + 1 <= denominator - 1) {
+      num1 += 1;
+    } else if (num1 - 1 >= 2) {
+      num1 -= 1;
+    } else {
+      num2 = Math.max(2, num2 - 1);
+    }
+    difference = num1 * denominator2 - num2 * denominator;
+  }
+  if (difference < 0) {
     [num1, num2] = [num2, num1];
     [denominator, denominator2] = [denominator2, denominator];
     difference *= -1;
   }
   const simplifiedAnswer = simplifyFraction(difference, denominator * denominator2);
-  // When denominator === denominator2 the "subtract straight across" distractor
-  // would divide by zero (Math.abs(d - d) === 0 → simplifyFraction returns the
-  // literal string 'undefined'). Fall back to a safe alternate distractor in
-  // that case so students never see "undefined" as an answer choice.
-  const subtractStraightDistractor = denominator === denominator2
-    ? simplifyFraction(Math.abs(num1 - num2), denominator)
-    : simplifyFraction(Math.abs(num1 - num2), Math.abs(denominator - denominator2));
-  const potentialDistractors = [
-    subtractStraightDistractor,
-    simplifyFraction(difference + 1, denominator * denominator2),
-    simplifyFraction(difference, denominator * denominator2 + 1),
+  // Build a bigger candidate pool of misconception distractors and pick the
+  // first three that do NOT collide with the correct answer or each other.
+  // Historical bugs:
+  //  1) When denominator === denominator2, "subtract straight across" simplifies
+  //     to the correct answer (or, in older code, divides by zero → "undefined").
+  //  2) When denominator2 is a multiple of denominator (e.g. 5/10 with base 5),
+  //     the "subtract numerators & subtract denominators" formula also
+  //     simplifies to the correct answer (e.g. 3/5 - 4/10 → distractor 1/5).
+  //  3) `simplifyFraction(diff + 1, common)` can coincidentally simplify to
+  //     match another distractor when diff+1 shares factors with the common
+  //     denominator.
+  const common_den = denominator * denominator2;
+  const candidateDistractors = [
+    // "Add the denominators" misconception — very common student error.
+    simplifyFraction(Math.abs(num1 - num2), denominator + denominator2),
+    // "Subtract numerators, subtract denominators" — only add when denominators
+    // differ (would be undefined otherwise). Kept lower-priority than the
+    // "add the denominators" candidate above since it can silently equal the
+    // correct answer when one denom is a multiple of the other.
+    denominator !== denominator2
+      ? simplifyFraction(Math.abs(num1 - num2), Math.abs(denominator - denominator2))
+      : null,
+    // Off-by-one on the simplified numerator (uses the simplified form so it
+    // reads as a plausible near-miss).
+    (() => {
+      const [an, ad] = simplifiedAnswer.includes('/')
+        ? simplifiedAnswer.split('/').map(Number)
+        : [Number(simplifiedAnswer), 1];
+      return simplifyFraction(an + 1, ad);
+    })(),
+    // Off-by-one on the un-simplified numerator.
+    simplifyFraction(difference + 1, common_den),
+    // Off-by-one on the un-simplified denominator.
+    simplifyFraction(difference, common_den + 1),
+    // "Forgot to find common denominator" — added numerators over d1.
+    simplifyFraction(num1 + num2, denominator),
   ];
+  const seen = new Set([simplifiedAnswer, 'undefined']);
+  const potentialDistractors = [];
+  for (const cand of candidateDistractors) {
+    if (cand == null || seen.has(cand)) continue;
+    potentialDistractors.push(cand);
+    seen.add(cand);
+    if (potentialDistractors.length === 3) break;
+  }
 
   return {
     question: `What is ${num1}/${denominator} - ${num2}/${denominator2}?`,

--- a/src/content/g4/geometry/__tests__/questions.test.js
+++ b/src/content/g4/geometry/__tests__/questions.test.js
@@ -2,6 +2,8 @@ import {
   ANGLE_TYPES,
   generateAngleMeasurementQuestion,
   generatePointsLinesRaysQuestion,
+  generateShapeClassificationQuestion,
+  generateQuadrilateralPropertiesQuestion,
   refreshAngleAdditionDiagram,
 } from '../questions.js';
 
@@ -183,5 +185,78 @@ describe('points / lines / rays questions', () => {
     const endpointQuestions = runMany(400).filter((q) => /How many endpoints/.test(q.question));
     expect(endpointQuestions.length).toBeGreaterThan(0); // the form does occur
     endpointQuestions.forEach((q) => expect(q.question).not.toMatch(/does a point have/));
+  });
+});
+
+describe('geometry angle "measure" question grammar', () => {
+  it('uses "An acute/obtuse angle measures:" and "A right/straight angle measures:"', () => {
+    // Old wording: "acute angle measures:" — missing an article.
+    let sawAny = false;
+    const wrongPairings = [];
+    for (let i = 0; i < 1000; i += 1) {
+      const q = generateAngleMeasurementQuestion();
+      const match = q.question.match(/^(A|An) (acute|right|obtuse|straight) angle measures:$/);
+      if (!match) continue;
+      sawAny = true;
+      const [, article, name] = match;
+      const expected = /^[aeiou]/i.test(name) ? 'An' : 'A';
+      if (article !== expected) {
+        wrongPairings.push(`${article} ${name}`);
+      }
+    }
+    expect(sawAny).toBe(true);
+    expect(wrongPairings).toEqual([]);
+    // Explicitly guard against the pre-fix wording.
+    for (let i = 0; i < 500; i += 1) {
+      const q = generateAngleMeasurementQuestion();
+      expect(q.question).not.toMatch(/^(acute|right|obtuse|straight) angle measures:$/);
+    }
+  });
+});
+
+describe('geometry shape classification: no hierarchy-driven ambiguity', () => {
+  it('never puts a subclass shape into the distractor pool (e.g., "square" when the answer is "rectangle")', () => {
+    // Rectangle description "opposite sides equal ... 4 right angles" is
+    // also satisfied by a square; rhombus description "4 equal sides" is
+    // also satisfied by a square; parallelogram description is satisfied by
+    // all three. Those must not appear as distractors.
+    const forbiddenBySubject = {
+      rectangle: ['square'],
+      rhombus: ['square'],
+      parallelogram: ['square', 'rectangle', 'rhombus'],
+    };
+    for (let i = 0; i < 500; i += 1) {
+      const q = generateShapeClassificationQuestion();
+      const forbidden = forbiddenBySubject[q.correctAnswer] || [];
+      forbidden.forEach((name) => {
+        expect(q.options).not.toContain(name);
+      });
+      // Sanity: correct answer is in options; options are distinct.
+      expect(q.options).toContain(q.correctAnswer);
+      expect(new Set(q.options).size).toBe(q.options.length);
+    }
+  });
+});
+
+describe('geometry quadrilateral properties: hierarchy-driven multiple correct answers are removed', () => {
+  it('never puts a subclass shape into the distractor pool for parallelogram / rectangle / rhombus', () => {
+    // The parallelogram property list is satisfied by squares, rectangles,
+    // and rhombuses. The rectangle and rhombus property lists are satisfied
+    // by squares. None of those subclass names should ever appear as
+    // distractors for their superclass question.
+    const forbiddenBySubject = {
+      rectangle: ['square'],
+      rhombus: ['square'],
+      parallelogram: ['square', 'rectangle', 'rhombus'],
+    };
+    for (let i = 0; i < 500; i += 1) {
+      const q = generateQuadrilateralPropertiesQuestion();
+      const forbidden = forbiddenBySubject[q.correctAnswer] || [];
+      forbidden.forEach((name) => {
+        expect(q.options).not.toContain(name);
+      });
+      expect(q.options).toContain(q.correctAnswer);
+      expect(new Set(q.options).size).toBe(q.options.length);
+    }
   });
 });

--- a/src/content/g4/geometry/questions.js
+++ b/src/content/g4/geometry/questions.js
@@ -503,31 +503,46 @@ export function generateShapeClassificationQuestion(difficulty = 0.5) {
       name: "square",
       description: "has 4 equal sides and 4 right angles",
       properties: ["4 sides", "all sides equal", "all angles 90°"],
+      // Subclass hierarchy: which other shapes also satisfy this description.
+      // Used to keep those out of the distractor pool so the question has a
+      // single mathematically-correct answer.
+      subclassOf: [],
     },
     {
       name: "rectangle",
-      description: "has 4 sides with opposite sides equal and 4 right angles",
+      description: "has 4 sides with opposite sides equal, adjacent sides of different lengths, and 4 right angles",
       properties: ["4 sides", "opposite sides equal", "all angles 90°"],
+      // Squares satisfy the generic rectangle description; the "adjacent sides
+      // of different lengths" clause above excludes squares mathematically,
+      // but keep them out of the distractor pool as a belt-and-suspenders.
+      subclassOf: ["square"],
     },
     {
       name: "triangle",
       description: "has 3 sides and 3 angles",
       properties: ["3 sides", "3 angles"],
+      subclassOf: [],
     },
     {
       name: "rhombus",
-      description: "has 4 equal sides but angles are not necessarily 90°",
+      description: "has 4 equal sides and no right angles",
       properties: ["4 sides", "all sides equal", "opposite angles equal"],
+      subclassOf: ["square"],
     },
     {
       name: "parallelogram",
-      description: "has 4 sides with opposite sides parallel and equal and angles not necessarily 90°",
+      description: "has 4 sides with opposite sides parallel and equal, adjacent sides of different lengths, and no right angles",
       properties: ["4 sides", "opposite sides parallel", "opposite sides equal"],
+      subclassOf: ["square", "rectangle", "rhombus"],
     },
   ];
-  
+
   const shape = shapes[getRandomInt(0, shapes.length - 1)];
-  const otherShapes = shapes.filter((s) => s.name !== shape.name);
+  // Exclude any shape that would also satisfy this description due to the
+  // quadrilateral hierarchy (e.g. squares also satisfy the rectangle
+  // description at the definition level).
+  const excludedNames = new Set([shape.name, ...shape.subclassOf]);
+  const otherShapes = shapes.filter((s) => !excludedNames.has(s.name));
   const wrongOptions = otherShapes
     .map((s) => s.name)
     .slice(0, 2);
@@ -647,36 +662,43 @@ export function generateQuadrilateralPropertiesQuestion(difficulty = 0.5) {
       name: "square",
       properties: [
         "all sides equal",
-        "all angles are 90°", 
+        "all angles are 90°",
         "opposite sides parallel",
         "4 lines of symmetry",
       ],
+      // Which other shape names would also correctly satisfy this property
+      // list under the quadrilateral hierarchy. Kept out of the distractor
+      // pool so the question has a single correct answer.
+      subclassOf: [],
     },
     {
       name: "rectangle",
       properties: [
-        "opposite sides equal",
+        "opposite sides equal but NOT all sides equal",
         "all angles are 90°",
-        "opposite sides parallel", 
+        "opposite sides parallel",
         "2 lines of symmetry",
       ],
+      subclassOf: ["square"],
     },
     {
       name: "rhombus",
       properties: [
         "all sides equal",
-        "opposite angles equal and not necessarily 90°",
+        "opposite angles equal but NOT all angles 90°",
         "opposite sides parallel",
         "2 lines of symmetry",
       ],
+      subclassOf: ["square"],
     },
     {
-      name: "parallelogram", 
+      name: "parallelogram",
       properties: [
-        "opposite sides equal",
-        "opposite angles equal and not necessarily 90°",
+        "opposite sides equal but NOT all sides equal",
+        "opposite angles equal but NOT all angles 90°",
         "opposite sides parallel",
       ],
+      subclassOf: ["square", "rectangle", "rhombus"],
     },
     {
       name: "trapezoid",
@@ -685,13 +707,17 @@ export function generateQuadrilateralPropertiesQuestion(difficulty = 0.5) {
         "can have different shapes",
         "may have a line of symmetry",
       ],
+      subclassOf: [],
     },
   ];
-  
+
   const quad = quadrilaterals[getRandomInt(0, quadrilaterals.length - 1)];
   const properties = quad.properties;
+  // Exclude any shape that is a subclass of the target — e.g. a square would
+  // otherwise be a defensible answer for the "parallelogram" question.
+  const excludedNames = new Set([quad.name, ...quad.subclassOf]);
   const wrongQuads = quadrilaterals
-    .filter(q => q.name !== quad.name)
+    .filter(q => !excludedNames.has(q.name))
     .map(q => q.name)
     .slice(0, 3);
   
@@ -859,7 +885,12 @@ export function generateAngleMeasurementQuestion(difficulty = 0.5) {
     },
     {
       type: "measure",
-      getQuestion: (angle) => `${angle.name} measures:`,
+      getQuestion: (angle) => {
+        // Use "an" only before names that start with a vowel sound
+        // ("acute", "obtuse"); use "a" before "right angle" / "straight angle".
+        const article = /^[aeiou]/i.test(angle.name) ? 'An' : 'A';
+        return `${article} ${angle.name} measures:`;
+      },
       correctAnswer: (angle) => angle.range,
     },
     {


### PR DESCRIPTION
## Summary

Six content bugs surfaced by adversarial review of every topic/subtopic generator in `src/content/`. Each one silently confuses a student — an option pool that collapses below 4 unique choices, a question with multiple mathematically-defensible answers, or an ungrammatical/nonsensical prompt.

Each fix comes with a targeted unit test that stresses the failure mode across 200–1000 random iterations. Full suite: **549 passed**.

### Bugs fixed

**G3 measurement-data** (`src/content/g3/measurement-data/questions.js`)
- Area: perimeter distractor `2*(l+w)` equals area `l*w` for pairs like (4,4), (3,6), (6,3). Distractor now shifts when it would collide.
- Volume: `l+w+h` sum distractor equals `l*w*h` for e.g. (3,2,1); can also collide with `volume-2`. Shifted on collision.

**G3 division** (`src/content/g3/division/questions.js`)
- Remainder distractors `[remainder+1, remainder-1, divisor]` duplicated `divisor` when `remainder+1 === divisor` (~1/3 of the time for divisor=3). Swaps in the quotient (or divisor+1 as a fallback).

**G3 fractions** (`src/content/g3/fractions/questions.js`)
- Equivalent-fractions could generate the degenerate 10/10 at difficulty=1 because `getRandomInt(min>max)` returns `min`. Clamped the numerator max so the denominator range always contains a value strictly greater than the numerator.

**G4 base-ten** (`src/content/g4/base-ten/questions.js`)
- Library word problem hardcoded "How many books and magazines do they have altogether?" even when the collection types were `["novels", "textbooks"]` or `["children's books", "adult books"]`. Now references the actual generated types.
- Rounding could pick a place larger than the number ("round 11,234 to the nearest million") producing a correct answer of 0 and a `rounded - divisor = -1,000,000` distractor. Caps the rounding place at the largest divisor the number can be rounded to, and guards against negative distractors.

**G4 fractions** (`src/content/g4/fractions/questions.js`)
- Subtraction distractor pool collapsed to the correct answer in three overlapping cases:
  1. Equal denominators — the "subtract straight across" formula IS the correct method
  2. `denominator2` a multiple of `denominator` — e.g. `3/5 − 4/10`, distractor simplifies to `1/5` = correct
  3. `diff + 1` sharing factors with the common denominator
  - Also handled the degenerate "equal fractions" case where `difference === 0` and multiple distractors all simplify to `"0"`
  - Rebuilt distractor generation as a bigger candidate list; picks the first three that don't collide with the correct answer or each other.

**G4 geometry** (`src/content/g4/geometry/questions.js`)
- Shape classification: descriptions failed the quadrilateral hierarchy — a square satisfies the generic rectangle / rhombus / parallelogram descriptions, so a student picking a defensible answer was marked wrong. Strengthened descriptions with distinguishing clauses ("adjacent sides of different lengths", "no right angles") AND excluded subclass shapes from the distractor pool as belt-and-suspenders.
- Quadrilateral properties: same hierarchy problem — the parallelogram property list is satisfied by every square, rectangle, and rhombus. Added "NOT all sides equal" / "NOT all angles 90°" distinguishing clauses and excluded subclass shapes from distractors.
- "Measure" question wording missed the article ("acute angle measures:" → "An acute angle measures:") — reused the vowel-check pattern from the real-life branch.

## Test plan

- [x] `npm test` (full jest suite): 549 pass, 0 fail
- [x] New tests specifically target each bug's failure mode with 200–1000 iterations
- [x] ESLint clean on all new tests and modified source
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_01PyaYGGXau3KzGxHkvXxTSo)_